### PR TITLE
feat: rename binaries to abaper, add man page and Homebrew tap

### DIFF
--- a/.github/workflows/dockerhub-cleanup.yaml
+++ b/.github/workflows/dockerhub-cleanup.yaml
@@ -1,0 +1,49 @@
+name: Docker Hub Cleanup
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags_to_delete:
+        description: "Comma-separated tags to delete (e.g. 0.1.0,0.2.0,beta)"
+        required: true
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Docker Hub JWT
+        id: auth
+        run: |
+          TOKEN=$(curl -s -X POST "https://hub.docker.com/v2/users/login/" \
+            -H "Content-Type: application/json" \
+            -d '{"username":"${{ secrets.DOCKERHUB_USER }}","password":"${{ secrets.DOCKERHUB_PASSWORD }}"}' \
+            | jq -r '.token')
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Delete tags
+        run: |
+          IFS=',' read -ra TAGS <<< "${{ inputs.tags_to_delete }}"
+          for tag in "${TAGS[@]}"; do
+            tag=$(echo "$tag" | xargs)  # trim whitespace
+            echo "Deleting tag: $tag"
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+              "https://hub.docker.com/v2/repositories/bluefunda/abaper/tags/$tag/" \
+              -H "Authorization: Bearer ${{ steps.auth.outputs.token }}")
+            echo "  -> HTTP $STATUS"
+          done
+
+  update-readme:
+    runs-on: ubuntu-latest
+    needs: cleanup
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: bluefunda/abaper
+          readme-filepath: ./README.md
+          short-description: "ABAPer CLI — command line interface for the ABAPer platform"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}
 
   docker:
     needs: release-please
@@ -79,3 +80,19 @@ jobs:
             bluefunda/abaper:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  dockerhub-readme:
+    needs: docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: bluefunda/abaper
+          readme-filepath: ./README.md
+          short-description: "ABAPer CLI — command line interface for the ABAPer platform"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 version: 2
+project_name: abaper
 
 before:
   hooks:
@@ -22,12 +23,29 @@ builds:
 archives:
   - format: tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - man/abaper.1
     format_overrides:
       - goos: windows
         format: zip
 
 checksum:
   name_template: "checksums.txt"
+
+brews:
+  - repository:
+      owner: bluefunda
+      name: homebrew-tap
+      token: "{{ .Env.GH_PAT }}"
+    directory: Formula
+    homepage: "https://abaper.bluefunda.com"
+    description: "Command line interface for the ABAPer platform"
+    license: "MIT"
+    install: |
+      bin.install "abaper"
+      man1.install "man/abaper.1"
+    test: |
+      system "#{bin}/abaper", "version"
 
 changelog:
   use: github-native

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN CGO_ENABLED=0 go build \
     -o /abaper ./cmd/abaper
 
 FROM alpine:3.21
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates man-db
 COPY --from=builder /abaper /usr/local/bin/abaper
+COPY man/abaper.1 /usr/local/share/man/man1/abaper.1
 ENTRYPOINT ["abaper"]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 LDFLAGS=-ldflags "-X github.com/bluefunda/abaper-cli/internal/commands.version=$(VERSION)"
 PLATFORMS=linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64
 
-.PHONY: build build-all clean test lint vet fmt run
+MANDIR ?= /usr/local/share/man/man1
+
+.PHONY: build build-all clean test lint vet fmt run install-man uninstall-man
 
 build:
 	go build $(LDFLAGS) -o bin/$(BINARY_NAME) ./cmd/abaper
@@ -36,6 +38,13 @@ build-all:
 		GOOS=$$os GOARCH=$$arch go build $(LDFLAGS) \
 			-o bin/$(BINARY_NAME)-$$os-$$arch$$ext ./cmd/abaper; \
 	done
+
+install-man:
+	install -d $(MANDIR)
+	install -m 644 man/abaper.1 $(MANDIR)/abaper.1
+
+uninstall-man:
+	rm -f $(MANDIR)/abaper.1
 
 docker-build:
 	docker build -t $(BINARY_NAME) .

--- a/README.md
+++ b/README.md
@@ -2,19 +2,51 @@
 
 Command line interface for the [ABAPer](https://abaper.bluefunda.com) platform. Communicates with ABAPer APIs exposed through the ABAPer gateway (`abaper-gw`).
 
+## Quick Start
+
+```bash
+# Install (macOS)
+brew tap bluefunda/tap
+brew install abaper
+
+# Authenticate
+abaper login
+
+# Verify connection
+abaper status
+
+# Create and deploy an ABAP program
+abaper generate --type program --name ZMY_REPORT
+abaper deploy --type program --name ZMY_REPORT --source-file report.abap
+```
+
 ## Installation
+
+### Homebrew (macOS)
+
+```bash
+brew tap bluefunda/tap
+brew install abaper
+```
+
+This installs the binary and the man page automatically.
 
 ### From GitHub Releases
 
 Download the binary for your platform from the [releases page](https://github.com/bluefunda/abaper-cli/releases).
 
-```bash
-# macOS (Apple Silicon)
-curl -L https://github.com/bluefunda/abaper-cli/releases/latest/download/abaper-cli_<version>_darwin_arm64.tar.gz | tar xz
-sudo mv abaper /usr/local/bin/
+| Platform       | Archive                              |
+|----------------|--------------------------------------|
+| macOS (ARM64)  | `abaper_<version>_darwin_arm64.tar.gz` |
+| macOS (AMD64)  | `abaper_<version>_darwin_amd64.tar.gz` |
+| Linux (AMD64)  | `abaper_<version>_linux_amd64.tar.gz`  |
+| Linux (ARM64)  | `abaper_<version>_linux_arm64.tar.gz`  |
+| Windows (AMD64)| `abaper_<version>_windows_amd64.zip`   |
+| Windows (ARM64)| `abaper_<version>_windows_arm64.zip`   |
 
-# Linux (amd64)
-curl -L https://github.com/bluefunda/abaper-cli/releases/latest/download/abaper-cli_<version>_linux_amd64.tar.gz | tar xz
+```bash
+# macOS / Linux
+curl -L https://github.com/bluefunda/abaper-cli/releases/latest/download/abaper_<version>_<os>_<arch>.tar.gz | tar xz
 sudo mv abaper /usr/local/bin/
 ```
 
@@ -27,55 +59,124 @@ go install github.com/bluefunda/abaper-cli/cmd/abaper@latest
 ### Docker
 
 ```bash
+docker pull bluefunda/abaper
 docker run --rm bluefunda/abaper version
 ```
 
-## Usage
+## Commands
 
-### Authentication
+### `abaper login`
+
+Authenticate with the ABAPer platform using the OAuth2 device authorization flow. Opens a browser window for interactive login. Credentials are stored locally in `~/.abaper/tokens.yaml` with restricted permissions (0600).
 
 ```bash
-# Login via browser-based device flow
 abaper login
+```
 
-# Check status
-abaper status
+### `abaper logout`
 
-# Logout
+Clear stored credentials by removing the local token file.
+
+```bash
 abaper logout
 ```
 
-### Developer Workflows
+### `abaper status`
+
+Show connection and authentication status. Reports the configured base URL, realm, organization, authentication state, and API health.
 
 ```bash
-# Generate a new ABAP program
+abaper status
+abaper status -o json
+```
+
+### `abaper generate`
+
+Create ABAP objects on the target SAP system. Supports programs, classes, and interfaces. Accepts source from a file or generates default templates.
+
+```bash
+# Generate with default template
 abaper generate --type program --name ZMY_PROGRAM
 
-# Generate a class with source from file
+# Generate from source file
 abaper generate --type class --name ZCL_MY_CLASS --source-file my_class.abap
 
-# Deploy (upload + activate)
-abaper deploy --type program --name ZMY_PROGRAM --source-file program.abap
+# Generate an interface
+abaper generate --type interface --name ZIF_MY_INTERFACE
+```
 
-# Check CLI version
+**Flags:**
+
+| Flag            | Required | Default   | Description                        |
+|-----------------|----------|-----------|------------------------------------|
+| `--name`        | Yes      | —         | Object name                        |
+| `--type`        | No       | `program` | Object type: program, class, interface |
+| `--source-file` | No       | —         | Path to ABAP source file           |
+
+### `abaper deploy`
+
+Upload source code and activate an ABAP object in a single step. Performs a save followed by activation, matching the workflow in ABAPer Editor.
+
+```bash
+abaper deploy --type program --name ZMY_PROGRAM --source-file program.abap
+```
+
+**Flags:**
+
+| Flag            | Required | Default   | Description                        |
+|-----------------|----------|-----------|------------------------------------|
+| `--name`        | Yes      | —         | Object name                        |
+| `--type`        | No       | `program` | Object type: program, class, interface |
+| `--source-file` | Yes      | —         | Path to ABAP source file           |
+
+### `abaper version`
+
+Print the CLI version.
+
+```bash
 abaper version
 ```
 
-### Output Formats
+## Man Page
 
-All commands support `--output json` for machine-readable output:
+A Unix man page is included. After installing the binary from a release archive:
 
 ```bash
-abaper status -o json
+# Install the man page (included in release archives)
+sudo install -m 644 man/abaper.1 /usr/local/share/man/man1/abaper.1
+
+# Or using make
+sudo make install-man
+
+# Then use it like any other Unix command
+man abaper
+```
+
+## Global Flags
+
+These flags are available on all commands:
+
+| Flag              | Description                                        |
+|-------------------|----------------------------------------------------|
+| `--base-url`      | ABAPer API base URL (default: `https://api.bluefunda.com`) |
+| `--realm`         | Keycloak realm (default: `trm`)                    |
+| `-o`, `--output`  | Output format: `text`, `json` (default: `text`)    |
+
+## Output Formats
+
+All commands support `--output json` for machine-readable output, useful for scripting and CI/CD pipelines:
+
+```bash
+abaper status -o json | jq '.authenticated'
 ```
 
 ## Configuration
 
-Configuration is loaded from (in order of precedence):
+Configuration is loaded in the following order of precedence:
 
-1. CLI flags (`--base-url`, `--realm`)
-2. Environment variables (`ABAPER_BASE_URL`, `ABAPER_REALM`, `ABAPER_ORG`)
-3. Config file `~/.abaper/config.yaml`
+1. **CLI flags** — `--base-url`, `--realm`
+2. **Environment variables** — `ABAPER_BASE_URL`, `ABAPER_REALM`, `ABAPER_ORG`
+3. **Config file** — `~/.abaper/config.yaml`
 
 ### Config File
 
@@ -86,7 +187,50 @@ realm: trm
 org: default
 ```
 
-Tokens are stored separately in `~/.abaper/tokens.yaml` with restricted permissions (0600).
+### Environment Variables
+
+| Variable          | Description                |
+|-------------------|----------------------------|
+| `ABAPER_BASE_URL` | Override the API base URL  |
+| `ABAPER_REALM`    | Override the Keycloak realm|
+| `ABAPER_ORG`      | Override the organization  |
+
+### Files
+
+| Path                      | Description                           |
+|---------------------------|---------------------------------------|
+| `~/.abaper/config.yaml`   | Configuration file                   |
+| `~/.abaper/tokens.yaml`   | OAuth2 tokens (permissions: 0600)    |
+
+## Authentication
+
+ABAPer CLI uses the **OAuth2 device authorization flow** via Keycloak (same flow as ABAPer VS Code extension):
+
+1. `abaper login` requests a device code from the authorization server
+2. Your browser opens to the verification URL
+3. The CLI polls for authorization completion
+4. Access and refresh tokens are stored locally
+
+Tokens are **automatically refreshed** when expired. The CLI uses the `cai-cli` OAuth2 client ID.
+
+## Docker Usage
+
+The CLI is available as a Docker image on Docker Hub under [`bluefunda/abaper`](https://hub.docker.com/r/bluefunda/abaper).
+
+```bash
+# Pull the latest image
+docker pull bluefunda/abaper:latest
+
+# Pull a specific version
+docker pull bluefunda/abaper:v1.0.0
+
+# Run a command
+docker run --rm bluefunda/abaper version
+docker run --rm bluefunda/abaper status -o json
+
+# Mount config for authenticated commands
+docker run --rm -v ~/.abaper:/root/.abaper bluefunda/abaper status
+```
 
 ## Developer Setup
 
@@ -114,20 +258,20 @@ make docker-run     # Run CLI in container
 
 ## Architecture
 
-The CLI follows the same API patterns as [abaper-editor](https://github.com/bluefunda/abaper-editor) and [abaper-vscode](https://github.com/bluefunda/abaper-vscode):
+The CLI follows the same API patterns as [ABAPer Editor](https://github.com/bluefunda/abaper-editor) and [ABAPer VS Code](https://github.com/bluefunda/abaper-vscode):
 
-- **Authentication**: OAuth2 device authorization flow via Keycloak (same as `abaper-vscode`)
+- **Authentication**: OAuth2 device authorization flow via Keycloak
 - **API Client**: Calls ABAPer APIs through the KrakenD gateway (`abaper-gw`) at `/abaper/api/v1/*`
 - **Request Headers**: `Authorization: Bearer <token>`, `X-Realm`, `X-SAP-*` headers
 - **Response Format**: `{ "success": bool, "data": T, "error": string }`
 
 ## Release Process
 
-Releases are automated via [release-please](https://github.com/googleapis/release-please) and follow the standards from [release-foundry](https://github.com/bluefunda/release-foundry).
+Releases are automated via [release-please](https://github.com/googleapis/release-please):
 
 1. Merge PRs with [conventional commit](https://www.conventionalcommits.org/) titles
 2. release-please creates a Release PR with version bump and changelog
 3. Merging the Release PR triggers:
-   - GoReleaser builds multi-platform binaries
+   - GoReleaser builds multi-platform binaries (named `abaper_<version>_<os>_<arch>`)
    - Binaries attached to GitHub Release
-   - Docker image pushed to `bluefunda/abaper`
+   - Docker image pushed to [`bluefunda/abaper`](https://hub.docker.com/r/bluefunda/abaper)

--- a/man/abaper.1
+++ b/man/abaper.1
@@ -1,0 +1,196 @@
+.TH ABAPER 1 "2026-03-11" "v1.0.0" "ABAPer CLI Manual"
+.SH NAME
+abaper \- command line interface for the ABAPer platform
+.SH SYNOPSIS
+.B abaper
+.I command
+.RI [ flags ]
+.SH DESCRIPTION
+.B abaper
+is a command line interface for the ABAPer platform.
+It communicates with ABAPer APIs exposed through the ABAPer gateway
+.RB ( abaper\-gw )
+to support developer workflows including authentication, code generation,
+deployment, and system inspection.
+.SH COMMANDS
+.TP
+.B login
+Authenticate with ABAPer using the OAuth2 device authorization flow.
+Opens a browser window for interactive login.
+Credentials are stored locally in
+.I ~/.abaper/tokens.yaml
+with restricted permissions (0600).
+.TP
+.B logout
+Clear stored credentials by removing the local token file.
+.TP
+.B status
+Show connection and authentication status.
+Reports the configured base URL, realm, organization, authentication state,
+and API health.
+.TP
+.B generate
+Create ABAP objects (programs, classes, interfaces) on the target SAP system.
+Accepts source from a file or generates default templates.
+See
+.BR abaper\-generate (1)
+for details.
+.TP
+.B deploy
+Upload source code and activate an ABAP object in a single step.
+Performs a save followed by activation, matching the workflow in ABAPer Editor.
+See
+.BR abaper\-deploy (1)
+for details.
+.TP
+.B version
+Print the CLI version.
+.SH GLOBAL FLAGS
+.TP
+.BI \-\-base\-url " url"
+ABAPer API base URL (default:
+.IR https://api.bluefunda.com ).
+.TP
+.BI \-\-realm " realm"
+Keycloak realm (default:
+.IR trm ).
+.TP
+.BR \-o ", " \-\-output " " \fIformat\fR
+Output format:
+.BR text " or " json
+(default:
+.IR text ).
+.SH GENERATE FLAGS
+.TP
+.BI \-\-name " name"
+Object name (required).
+.TP
+.BI \-\-type " type"
+Object type:
+.BR program ", " class ", or " interface
+(default:
+.IR program ).
+.TP
+.BI \-\-source\-file " path"
+Path to ABAP source file. If omitted, a default template is generated.
+.SH DEPLOY FLAGS
+.TP
+.BI \-\-name " name"
+Object name (required).
+.TP
+.BI \-\-type " type"
+Object type:
+.BR program ", " class ", or " interface
+(default:
+.IR program ).
+.TP
+.BI \-\-source\-file " path"
+Path to ABAP source file (required).
+.SH AUTHENTICATION
+ABAPer CLI uses the OAuth2 device authorization flow via Keycloak
+(same flow as the ABAPer VS Code extension):
+.PP
+.RS 4
+1. \fBabaper login\fR requests a device code from the authorization server
+.br
+2. Your browser opens to the verification URL
+.br
+3. The CLI polls for authorization completion
+.br
+4. Access and refresh tokens are stored locally
+.RE
+.PP
+Tokens are automatically refreshed when expired.
+The CLI uses the
+.B cai\-cli
+OAuth2 client ID.
+.SH CONFIGURATION
+Configuration is loaded in the following order of precedence:
+.PP
+.RS 4
+1. CLI flags (\fB\-\-base\-url\fR, \fB\-\-realm\fR)
+.br
+2. Environment variables (\fBABAPER_BASE_URL\fR, \fBABAPER_REALM\fR, \fBABAPER_ORG\fR)
+.br
+3. Config file \fI~/.abaper/config.yaml\fR
+.RE
+.SS Config File Format
+.PP
+.RS 4
+.nf
+base_url: https://api.bluefunda.com
+realm: trm
+org: default
+.fi
+.RE
+.SH ENVIRONMENT
+.TP
+.B ABAPER_BASE_URL
+Override the API base URL.
+.TP
+.B ABAPER_REALM
+Override the Keycloak realm.
+.TP
+.B ABAPER_ORG
+Override the organization.
+.SH FILES
+.TP
+.I ~/.abaper/config.yaml
+Configuration file.
+.TP
+.I ~/.abaper/tokens.yaml
+OAuth2 tokens. Created with permissions 0600.
+.SH EXAMPLES
+Authenticate and check connection:
+.PP
+.RS 4
+.nf
+abaper login
+abaper status
+.fi
+.RE
+.PP
+Create and deploy an ABAP program:
+.PP
+.RS 4
+.nf
+abaper generate \-\-type program \-\-name ZMY_REPORT
+abaper deploy \-\-type program \-\-name ZMY_REPORT \-\-source\-file report.abap
+.fi
+.RE
+.PP
+Use JSON output for scripting:
+.PP
+.RS 4
+.nf
+abaper status \-o json | jq '.authenticated'
+.fi
+.RE
+.PP
+Run via Docker:
+.PP
+.RS 4
+.nf
+docker run \-\-rm bluefunda/abaper version
+docker run \-\-rm \-v ~/.abaper:/root/.abaper bluefunda/abaper status
+.fi
+.RE
+.SH DOCKER
+The CLI is available as a Docker image at
+.BR bluefunda/abaper " on Docker Hub."
+.PP
+.RS 4
+.nf
+docker pull bluefunda/abaper:latest
+docker pull bluefunda/abaper:v1.0.0
+.fi
+.RE
+.SH SEE ALSO
+.UR https://abaper.bluefunda.com
+ABAPer platform
+.UE ,
+.UR https://github.com/bluefunda/abaper\-cli
+Source code & releases
+.UE
+.SH AUTHORS
+Bluefunda <https://bluefunda.com>


### PR DESCRIPTION
## Summary
Rename release binaries from `abaper-cli_*` to `abaper_*`, add a Unix man page (`man abaper`), and configure Homebrew tap auto-publishing so users can install via `brew tap bluefunda/tap && brew install abaper`.

## Type
- [x] feature
- [ ] fix
- [ ] performance
- [ ] security
- [x] infrastructure

## Customer Impact
Users can now install ABAPer CLI via Homebrew (`brew install abaper`) with automatic man page support (`man abaper`). Binary naming is simplified from `abaper-cli` to `abaper` across all release artifacts. Docker Hub README is kept in sync automatically.

## Test Plan
- [x] `go build ./cmd/abaper` compiles cleanly
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] `man man/abaper.1` renders correctly
- [ ] Verify goreleaser produces `abaper_*` archives on next release
- [ ] Verify Homebrew formula is published to `bluefunda/homebrew-tap`
- [ ] Verify `brew tap bluefunda/tap && brew install abaper` works
- [ ] Verify Docker Hub README sync via `dockerhub-readme` job
- [ ] Run `dockerhub-cleanup` workflow to remove old tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)