### PR TITLE
fix: use homebrew_casks, HOMEBREW_TAP_TOKEN, and correct DOCKERHUB_TOKEN

### DIFF
--- a/.github/workflows/dockerhub-cleanup.yaml
+++ b/.github/workflows/dockerhub-cleanup.yaml
@@ -16,7 +16,7 @@ jobs:
         run: |
           TOKEN=$(curl -s -X POST "https://hub.docker.com/v2/users/login/" \
             -H "Content-Type: application/json" \
-            -d '{"username":"${{ secrets.DOCKERHUB_USER }}","password":"${{ secrets.DOCKERHUB_PASSWORD }}"}' \
+            -d '{"username":"${{ secrets.DOCKERHUB_USER }}","password":"${{ secrets.DOCKERHUB_TOKEN }}"}' \
             | jq -r '.token')
           echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
 
@@ -43,7 +43,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: bluefunda/abaper
           readme-filepath: ./README.md
           short-description: "ABAPer CLI — command line interface for the ABAPer platform"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_PAT: ${{ secrets.GH_PAT }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
   docker:
     needs: release-please
@@ -92,7 +92,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: bluefunda/abaper
           readme-filepath: ./README.md
           short-description: "ABAPer CLI — command line interface for the ABAPer platform"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,20 +32,18 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
-brews:
+homebrew_casks:
   - repository:
       owner: bluefunda
       name: homebrew-tap
-      token: "{{ .Env.GH_PAT }}"
-    directory: Formula
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Casks
     homepage: "https://abaper.bluefunda.com"
     description: "Command line interface for the ABAPer platform"
-    license: "MIT"
-    install: |
-      bin.install "abaper"
-      man1.install "man/abaper.1"
-    test: |
-      system "#{bin}/abaper", "version"
+    binaries:
+      - abaper
+    manpages:
+      - man/abaper.1
 
 changelog:
   use: github-native


### PR DESCRIPTION
## Summary
Fix the three CI/CD failures from the v1.1.0 release: goreleaser `brews` deprecation, wrong Homebrew PAT secret, and missing Docker Hub password secret.

## Type
- [ ] feature
- [x] fix
- [ ] performance
- [ ] security
- [x] infrastructure

## Customer Impact
Unblocks automated Homebrew formula publishing and Docker Hub README sync on release.

## Test Plan
- [x] `go build` / `go vet` pass
- [ ] Verify `HOMEBREW_TAP_TOKEN` secret is added to repo (scoped to `bluefunda/homebrew-tap` with Contents: write)
- [ ] Verify goreleaser no longer warns about `brews` deprecation
- [ ] Verify `dockerhub-readme` job succeeds with `DOCKERHUB_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)