### PR TITLE
feat: add AI chat, unit tests, list, and missing gateway API coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,72 @@ abaper deploy --type program --name ZMY_PROGRAM --source-file program.abap
 | `--type`        | No       | `program` | Object type: program, class, interface |
 | `--source-file` | Yes      | —         | Path to ABAP source file           |
 
+### `abaper test`
+
+Run ABAP unit tests for an object on the target SAP system.
+
+```bash
+abaper test --type class --name ZCL_MY_CLASS
+abaper test --type class --name ZCL_MY_CLASS -o json
+```
+
+**Flags:**
+
+| Flag     | Required | Default | Description                  |
+|----------|----------|---------|------------------------------|
+| `--name` | Yes      | —       | Object name                  |
+| `--type` | No       | `class` | Object type: class, program  |
+
+### `abaper list objects`
+
+List ABAP objects, optionally filtered by package or type.
+
+```bash
+abaper list objects --package ZDEV
+abaper list objects --type program
+```
+
+**Flags:**
+
+| Flag        | Required | Default | Description               |
+|-------------|----------|---------|---------------------------|
+| `--package` | No       | —       | Filter by package name    |
+| `--type`    | No       | —       | Filter by object type     |
+
+### `abaper list packages`
+
+List contents of an ABAP package.
+
+```bash
+abaper list packages --name ZDEV
+```
+
+### `abaper ai chat`
+
+Send a prompt to the ABAPer AI assistant and stream the response. Supports including ABAP source files as context and resuming existing chat sessions.
+
+```bash
+# Ask a question
+abaper ai chat "Explain SELECT FOR ALL ENTRIES in ABAP"
+
+# Include source context
+abaper ai chat "Optimize this code" --context-file program.abap
+
+# Resume a previous chat
+abaper ai chat "What about performance?" --chat-id <previous-chat-id>
+
+# JSON output for scripting
+abaper ai chat "Review this code" --context-file report.abap -o json
+```
+
+**Flags:**
+
+| Flag              | Required | Default | Description                          |
+|-------------------|----------|---------|--------------------------------------|
+| `--model`         | No       | `groq`  | LLM model to use                     |
+| `--context-file`  | No       | —       | ABAP source file to include as context |
+| `--chat-id`       | No       | —       | Resume an existing chat session      |
+
 ### `abaper version`
 
 Print the CLI version.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 require (
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIx
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/client/abaper_api.go
+++ b/internal/client/abaper_api.go
@@ -1,11 +1,14 @@
 package client
 
 import (
+	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/bluefunda/abaper-cli/internal/config"
@@ -289,4 +292,184 @@ func (c *Client) CreateTransport(description, targetPackage string) (string, err
 		return "", err
 	}
 	return result.Transport, nil
+}
+
+// GatewayVersion retrieves the gateway version.
+func (c *Client) GatewayVersion() (map[string]string, error) {
+	resp, err := c.Do(http.MethodGet, "/version", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// ListObjects lists ABAP objects in a package.
+func (c *Client) ListObjects(packageName, objectType string) ([]map[string]any, error) {
+	body := map[string]string{}
+	if packageName != "" {
+		body["package"] = packageName
+	}
+	if objectType != "" {
+		body["object_type"] = objectType
+	}
+
+	type ListResult struct {
+		Objects []map[string]any `json:"Objects"`
+	}
+
+	result, err := Post[ListResult](c, "/api/v1/objects/list", body)
+	if err != nil {
+		return nil, err
+	}
+	return result.Objects, nil
+}
+
+// RunUnitTests executes ABAP unit tests for an object.
+func (c *Client) RunUnitTests(objectName, objectType string) (*map[string]any, error) {
+	body := map[string]string{
+		"object_name": objectName,
+		"object_type": objectType,
+	}
+	return Post[map[string]any](c, "/api/v1/unit-tests", body)
+}
+
+// Completion retrieves code completion suggestions.
+func (c *Client) Completion(objectName, objectType, source string, line, column int) (*map[string]any, error) {
+	body := map[string]any{
+		"object_name": objectName,
+		"object_type": objectType,
+		"source":      source,
+		"line":        line,
+		"column":      column,
+	}
+	return Post[map[string]any](c, "/api/v1/completion", body)
+}
+
+// Navigation retrieves code navigation (go-to-definition) results.
+func (c *Client) Navigation(objectName, objectType, source string, line, column int) (*map[string]any, error) {
+	body := map[string]any{
+		"object_name": objectName,
+		"object_type": objectType,
+		"source":      source,
+		"line":        line,
+		"column":      column,
+	}
+	return Post[map[string]any](c, "/api/v1/navigation", body)
+}
+
+// PackageContents lists the contents of a package.
+func (c *Client) PackageContents(packageName string) ([]map[string]any, error) {
+	body := map[string]string{
+		"package": packageName,
+	}
+
+	type PkgResult struct {
+		Objects []map[string]any `json:"Objects"`
+	}
+
+	result, err := Post[PkgResult](c, "/api/v1/packages/contents", body)
+	if err != nil {
+		return nil, err
+	}
+	return result.Objects, nil
+}
+
+// ChatEvent represents a single event from the AI chat SSE stream.
+type ChatEvent struct {
+	Type          string `json:"type"`
+	Content       string `json:"content,omitempty"`
+	FullContent   string `json:"full_content,omitempty"`
+	Error         string `json:"error,omitempty"`
+	Message       string `json:"message,omitempty"`
+	SessionID     string `json:"session_id,omitempty"`
+	ToolName      string `json:"tool_name,omitempty"`
+	Status        string `json:"status,omitempty"`
+	DurationMs    int    `json:"duration_ms,omitempty"`
+	ResultSummary string `json:"result_summary,omitempty"`
+}
+
+// ChatRequest is the request body for AI chat.
+type ChatRequest struct {
+	Prompt    string `json:"prompt"`
+	Model     string `json:"model"`
+	AgentName string `json:"agentName"`
+	IsNewChat bool   `json:"isNewChat"`
+}
+
+// StreamChat sends a prompt to the AI chat endpoint and streams SSE events.
+func (c *Client) StreamChat(ctx context.Context, chatID string, req ChatRequest, handler func(ChatEvent)) error {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal chat request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.BaseURL+"/abaper/ai/chats/"+chatID, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+	httpReq.Header.Set("Authorization", "Bearer "+c.Token)
+	httpReq.Header.Set("X-Realm", c.Realm)
+
+	sseClient := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := sseClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("chat request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		text, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("chat API error %d: %s", resp.StatusCode, string(text))
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		if payload == "[DONE]" {
+			break
+		}
+
+		var event ChatEvent
+		if err := json.Unmarshal([]byte(payload), &event); err != nil {
+			continue
+		}
+		handler(event)
+
+		if event.Type == "stream_end" || event.Type == "error" || event.Type == "stream_error" {
+			break
+		}
+	}
+
+	return scanner.Err()
+}
+
+// ChatTitle generates a title for a chat session.
+func (c *Client) ChatTitle(chatID, prompt string) (string, error) {
+	body := map[string]string{"prompt": prompt}
+	type TitleResult struct {
+		GeneratedTitle string `json:"generatedTitle"`
+		Title          string `json:"title"`
+	}
+	result, err := Post[TitleResult](c, "/ai/chats/"+chatID+"/title", body)
+	if err != nil {
+		return "", err
+	}
+	if result.GeneratedTitle != "" {
+		return result.GeneratedTitle, nil
+	}
+	return result.Title, nil
 }

--- a/internal/commands/ai.go
+++ b/internal/commands/ai.go
@@ -1,0 +1,120 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/bluefunda/abaper-cli/internal/client"
+	"github.com/bluefunda/abaper-cli/pkg/output"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+)
+
+var aiCmd = &cobra.Command{
+	Use:   "ai",
+	Short: "AI-powered developer assistance",
+	Long:  "Interact with ABAPer AI features including chat and code analysis.",
+}
+
+var aiChatCmd = &cobra.Command{
+	Use:   "chat [prompt]",
+	Short: "Start an AI chat session",
+	Long: `Send a prompt to the ABAPer AI assistant and stream the response.
+Optionally include ABAP source context from a file.`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: runAIChat,
+}
+
+func init() {
+	aiChatCmd.Flags().String("model", "groq", "LLM model to use")
+	aiChatCmd.Flags().String("context-file", "", "ABAP source file to include as context")
+	aiChatCmd.Flags().String("chat-id", "", "Resume an existing chat session (default: new session)")
+
+	aiCmd.AddCommand(aiChatCmd)
+}
+
+func runAIChat(cmd *cobra.Command, args []string) error {
+	prompt := args[0]
+	model, _ := cmd.Flags().GetString("model")
+	contextFile, _ := cmd.Flags().GetString("context-file")
+	chatID, _ := cmd.Flags().GetString("chat-id")
+
+	if contextFile != "" {
+		data, err := os.ReadFile(contextFile)
+		if err != nil {
+			return fmt.Errorf("read context file: %w", err)
+		}
+		prompt = fmt.Sprintf("%s\n\nContext:\n```abap\n%s\n```", prompt, string(data))
+	}
+
+	isNewChat := chatID == ""
+	if isNewChat {
+		chatID = uuid.New().String()
+	}
+
+	c, err := client.NewClient()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	outputFmt, _ := cmd.Flags().GetString("output")
+
+	req := client.ChatRequest{
+		Prompt:    prompt,
+		Model:     model,
+		AgentName: "abaper",
+		IsNewChat: isNewChat,
+	}
+
+	if outputFmt == "json" {
+		var fullContent string
+		var events []client.ChatEvent
+		err = c.StreamChat(ctx, chatID, req, func(event client.ChatEvent) {
+			events = append(events, event)
+			if event.Content != "" {
+				fullContent += event.Content
+			}
+			if event.FullContent != "" {
+				fullContent = event.FullContent
+			}
+		})
+		if err != nil {
+			return fmt.Errorf("chat failed: %w", err)
+		}
+		output.PrintJSON(map[string]any{
+			"chat_id": chatID,
+			"content": fullContent,
+			"events":  events,
+		})
+	} else {
+		err = c.StreamChat(ctx, chatID, req, func(event client.ChatEvent) {
+			switch event.Type {
+			case "stream_chunk":
+				fmt.Print(event.Content)
+			case "stream_end":
+				fmt.Println()
+			case "stream_tool_execution":
+				fmt.Fprintf(os.Stderr, "\n[tool: %s — %s]\n", event.ToolName, event.Status)
+			case "stream_progress":
+				fmt.Fprintf(os.Stderr, "[thinking...]\n")
+			case "error", "stream_error":
+				msg := event.Error
+				if msg == "" {
+					msg = event.Message
+				}
+				fmt.Fprintf(os.Stderr, "\nError: %s\n", msg)
+			}
+		})
+		if err != nil {
+			return fmt.Errorf("chat failed: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "\nchat-id: %s\n", chatID)
+	}
+
+	return nil
+}

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bluefunda/abaper-cli/internal/client"
+	"github.com/bluefunda/abaper-cli/pkg/output"
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List ABAP objects or package contents",
+}
+
+var listObjectsCmd = &cobra.Command{
+	Use:   "objects",
+	Short: "List ABAP objects, optionally filtered by package or type",
+	RunE:  runListObjects,
+}
+
+var listPackagesCmd = &cobra.Command{
+	Use:   "packages",
+	Short: "List contents of an ABAP package",
+	RunE:  runListPackages,
+}
+
+func init() {
+	listObjectsCmd.Flags().String("package", "", "Filter by package name")
+	listObjectsCmd.Flags().String("type", "", "Filter by object type")
+
+	listPackagesCmd.Flags().String("name", "", "Package name (required)")
+	_ = listPackagesCmd.MarkFlagRequired("name")
+
+	listCmd.AddCommand(listObjectsCmd)
+	listCmd.AddCommand(listPackagesCmd)
+}
+
+func runListObjects(cmd *cobra.Command, args []string) error {
+	packageName, _ := cmd.Flags().GetString("package")
+	objectType, _ := cmd.Flags().GetString("type")
+
+	c, err := client.NewClient()
+	if err != nil {
+		return err
+	}
+
+	objects, err := c.ListObjects(packageName, objectType)
+	if err != nil {
+		return fmt.Errorf("list objects failed: %w", err)
+	}
+
+	outputFmt, _ := cmd.Flags().GetString("output")
+	if outputFmt == "json" {
+		output.PrintJSON(objects)
+	} else {
+		if len(objects) == 0 {
+			fmt.Println("No objects found.")
+			return nil
+		}
+		for _, obj := range objects {
+			parts := []string{}
+			if t, ok := obj["object_type"]; ok {
+				parts = append(parts, fmt.Sprintf("%v", t))
+			}
+			if n, ok := obj["object_name"]; ok {
+				parts = append(parts, fmt.Sprintf("%v", n))
+			}
+			fmt.Println(strings.Join(parts, "\t"))
+		}
+	}
+
+	return nil
+}
+
+func runListPackages(cmd *cobra.Command, args []string) error {
+	packageName, _ := cmd.Flags().GetString("name")
+
+	c, err := client.NewClient()
+	if err != nil {
+		return err
+	}
+
+	objects, err := c.PackageContents(packageName)
+	if err != nil {
+		return fmt.Errorf("package contents failed: %w", err)
+	}
+
+	outputFmt, _ := cmd.Flags().GetString("output")
+	if outputFmt == "json" {
+		output.PrintJSON(objects)
+	} else {
+		if len(objects) == 0 {
+			fmt.Println("No objects found in package.")
+			return nil
+		}
+		for _, obj := range objects {
+			parts := []string{}
+			if t, ok := obj["object_type"]; ok {
+				parts = append(parts, fmt.Sprintf("%v", t))
+			}
+			if n, ok := obj["object_name"]; ok {
+				parts = append(parts, fmt.Sprintf("%v", n))
+			}
+			fmt.Println(strings.Join(parts, "\t"))
+		}
+	}
+
+	return nil
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -30,6 +30,9 @@ func init() {
 	rootCmd.AddCommand(deployCmd)
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(aiCmd)
+	rootCmd.AddCommand(testCmd)
+	rootCmd.AddCommand(listCmd)
 }
 
 func Execute() error {

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/bluefunda/abaper-cli/internal/client"
+	"github.com/bluefunda/abaper-cli/pkg/output"
+	"github.com/spf13/cobra"
+)
+
+var testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Run ABAP unit tests for an object",
+	RunE:  runTest,
+}
+
+func init() {
+	testCmd.Flags().String("type", "class", "Object type: class, program")
+	testCmd.Flags().String("name", "", "Object name (required)")
+	_ = testCmd.MarkFlagRequired("name")
+}
+
+func runTest(cmd *cobra.Command, args []string) error {
+	objectType, _ := cmd.Flags().GetString("type")
+	objectName, _ := cmd.Flags().GetString("name")
+
+	c, err := client.NewClient()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Running unit tests for %s %s...\n", objectType, objectName)
+	result, err := c.RunUnitTests(objectName, objectType)
+	if err != nil {
+		return fmt.Errorf("unit tests failed: %w", err)
+	}
+
+	outputFmt, _ := cmd.Flags().GetString("output")
+	if outputFmt == "json" {
+		output.PrintJSON(result)
+	} else {
+		output.PrintJSON(result)
+	}
+
+	return nil
+}

--- a/man/abaper.1
+++ b/man/abaper.1
@@ -43,6 +43,19 @@ See
 .BR abaper\-deploy (1)
 for details.
 .TP
+.B test
+Run ABAP unit tests for an object on the target system.
+.TP
+.B list objects
+List ABAP objects, optionally filtered by package or type.
+.TP
+.B list packages
+List contents of an ABAP package.
+.TP
+.B ai chat
+Send a prompt to the ABAPer AI assistant and stream the response.
+Supports context injection from ABAP source files and session resumption.
+.TP
 .B version
 Print the CLI version.
 .SH GLOBAL FLAGS
@@ -86,6 +99,37 @@ Object type:
 .TP
 .BI \-\-source\-file " path"
 Path to ABAP source file (required).
+.SH AI CHAT FLAGS
+.TP
+.BI \-\-model " model"
+LLM model to use (default:
+.IR groq ).
+.TP
+.BI \-\-context\-file " path"
+ABAP source file to include as context with the prompt.
+.TP
+.BI \-\-chat\-id " id"
+Resume an existing chat session. If omitted, a new session is created.
+.SH TEST FLAGS
+.TP
+.BI \-\-name " name"
+Object name (required).
+.TP
+.BI \-\-type " type"
+Object type:
+.BR class " or " program
+(default:
+.IR class ).
+.SH LIST FLAGS
+.TP
+.BI \-\-package " name"
+Filter objects by package name (list objects).
+.TP
+.BI \-\-type " type"
+Filter objects by type (list objects).
+.TP
+.BI \-\-name " name"
+Package name (list packages, required).
 .SH AUTHENTICATION
 ABAPer CLI uses the OAuth2 device authorization flow via Keycloak
 (same flow as the ABAPer VS Code extension):
@@ -156,6 +200,33 @@ Create and deploy an ABAP program:
 .nf
 abaper generate \-\-type program \-\-name ZMY_REPORT
 abaper deploy \-\-type program \-\-name ZMY_REPORT \-\-source\-file report.abap
+.fi
+.RE
+.PP
+AI-assisted development:
+.PP
+.RS 4
+.nf
+abaper ai chat "Explain SELECT FOR ALL ENTRIES"
+abaper ai chat "Optimize this code" \-\-context\-file program.abap
+abaper ai chat "What about performance?" \-\-chat\-id <previous\-id>
+.fi
+.RE
+.PP
+Run unit tests:
+.PP
+.RS 4
+.nf
+abaper test \-\-type class \-\-name ZCL_MY_CLASS
+.fi
+.RE
+.PP
+List objects and packages:
+.PP
+.RS 4
+.nf
+abaper list objects \-\-package ZDEV
+abaper list packages \-\-name ZDEV
 .fi
 .RE
 .PP


### PR DESCRIPTION
## Summary
Add CLI commands and client methods for all abaper-gw API endpoints that were missing. The CLI now covers every endpoint exposed by the gateway, matching feature parity with abaper-editor and abaper-vscode.

## Type
- [x] feature
- [ ] fix
- [ ] performance
- [ ] security
- [ ] infrastructure

## Customer Impact
Users can now access AI-powered features from the command line — streaming chat with context injection, unit test execution, object listing, and package browsing. This enables CI/CD pipelines and terminal-based workflows to leverage the full ABAPer platform.

## New Commands
- `abaper ai chat` — streaming AI chat with SSE, context file support, session resumption
- `abaper test` — run ABAP unit tests
- `abaper list objects` — list objects by package/type
- `abaper list packages` — browse package contents

## New Client Methods
- `GatewayVersion()` → `/version`
- `ListObjects()` → `/api/v1/objects/list`
- `RunUnitTests()` → `/api/v1/unit-tests`
- `Completion()` → `/api/v1/completion`
- `Navigation()` → `/api/v1/navigation`
- `PackageContents()` → `/api/v1/packages/contents`
- `StreamChat()` → `/ai/chats/{id}` (SSE)
- `ChatTitle()` → `/ai/chats/{id}/title`

## Test Plan
- [x] `go build ./...` compiles
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] `abaper --help` shows all new commands
- [x] `man abaper.1` renders updated man page
- [ ] Integration test: `abaper ai chat "hello"` streams response
- [ ] Integration test: `abaper test --name ZCL_TEST --type class`
- [ ] Integration test: `abaper list objects --package ZDEV`

🤖 Generated with [Claude Code](https://claude.com/claude-code)