### PR TITLE
fix: use RELEASE_PAT for release-please workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         id: release
         with:
           release-type: go
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.RELEASE_PAT }}
 
   goreleaser:
     needs: release-please


### PR DESCRIPTION
## Summary
- Switch release-please token from `GH_PAT` to `RELEASE_PAT` secret
- `GH_PAT` lacked `Contents: write` fine-grained permission, causing release-please to fail when creating the release branch

## Test plan
- [ ] Verify CI passes
- [ ] Merge and confirm release-please can create the release PR on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)