### PR TITLE
feat: add telemetry, signup command, route login through bluefunda.com

### DIFF
--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -33,7 +33,7 @@ type AuthErrorResponse struct {
 }
 
 func authBaseURL(realm string) string {
-	return fmt.Sprintf("https://auth.bluefunda.com/realms/%s/protocol/openid-connect", realm)
+	return fmt.Sprintf("https://ai.bluefunda.com/realms/%s/protocol/openid-connect", realm)
 }
 
 func RequestDeviceCode(realm string) (*DeviceAuthResponse, error) {

--- a/internal/client/telemetry.go
+++ b/internal/client/telemetry.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"runtime"
+	"time"
+
+	"github.com/bluefunda/abaper-cli/internal/config"
+)
+
+type telemetryEvent struct {
+	Event      string         `json:"event"`
+	Properties map[string]any `json:"properties"`
+}
+
+// Track sends a telemetry event to the ABAPer API.
+// It is fire-and-forget — errors are silently ignored.
+func Track(event string, extra map[string]string) {
+	cfg := config.Load()
+
+	props := map[string]any{
+		"client":   "cli",
+		"platform": runtime.GOOS,
+		"arch":     runtime.GOARCH,
+	}
+	for k, v := range extra {
+		props[k] = v
+	}
+
+	body, err := json.Marshal(telemetryEvent{Event: event, Properties: props})
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequest("POST", cfg.BaseURL+"/abaper/telemetry", bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Include auth token if available
+	tokens, err := config.LoadTokens()
+	if err == nil && tokens.AccessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	_ = resp.Body.Close()
+}

--- a/internal/commands/ai.go
+++ b/internal/commands/ai.go
@@ -54,6 +54,8 @@ func runAIChat(cmd *cobra.Command, args []string) error {
 		chatID = uuid.New().String()
 	}
 
+	go client.Track("chat_opened", nil)
+
 	c, err := client.NewClient()
 	if err != nil {
 		return err

--- a/internal/commands/login.go
+++ b/internal/commands/login.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"net/url"
 	"os/exec"
 	"runtime"
 	"time"
@@ -28,6 +29,7 @@ var logoutCmd = &cobra.Command{
 			return fmt.Errorf("logout: %w", err)
 		}
 		fmt.Println("Logged out successfully.")
+		go client.Track("logout", nil)
 		return nil
 	},
 }
@@ -36,6 +38,8 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	cfg := config.Load()
 	realm := cfg.Realm
 
+	go client.Track("login_started", nil)
+
 	// Step 1: Request device code
 	fmt.Println("Requesting device authorization...")
 	deviceResp, err := client.RequestDeviceCode(realm)
@@ -43,16 +47,18 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("login failed: %w", err)
 	}
 
-	// Step 2: Open browser
+	// Step 2: Open browser via bluefunda.com/login
 	verifyURL := deviceResp.VerificationURIComplete
 	if verifyURL == "" {
 		verifyURL = deviceResp.VerificationURI
 	}
+	loginURL := fmt.Sprintf("https://bluefunda.com/login?redirect_uri=%s&utm_source=cli&utm_medium=command&utm_campaign=login",
+		url.QueryEscape(verifyURL))
 
-	fmt.Printf("\nOpen this URL in your browser to log in:\n  %s\n\n", verifyURL)
+	fmt.Printf("\nOpen this URL in your browser to log in:\n  %s\n\n", loginURL)
 	fmt.Printf("Your code: %s\n\n", deviceResp.UserCode)
 
-	_ = openBrowser(verifyURL)
+	_ = openBrowser(loginURL)
 
 	// Step 3: Poll for token
 	fmt.Println("Waiting for authorization...")
@@ -73,6 +79,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Successfully logged in!")
+	go client.Track("login_completed", map[string]string{"success": "true"})
 	return nil
 }
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/bluefunda/abaper-cli/internal/client"
 	"github.com/bluefunda/abaper-cli/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -15,6 +16,9 @@ It communicates with ABAPer APIs exposed through the ABAPer gateway
 to support developer workflows including code generation, compilation,
 deployment, and inspection.`,
 	SilenceUsage: true,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		go client.Track("cli_invoked", map[string]string{"command": cmd.Name()})
+	},
 }
 
 func init() {
@@ -26,6 +30,7 @@ func init() {
 
 	rootCmd.AddCommand(loginCmd)
 	rootCmd.AddCommand(logoutCmd)
+	rootCmd.AddCommand(signupCmd)
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(deployCmd)
 	rootCmd.AddCommand(statusCmd)

--- a/internal/commands/signup.go
+++ b/internal/commands/signup.go
@@ -1,0 +1,22 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/bluefunda/abaper-cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+var signupCmd = &cobra.Command{
+	Use:   "signup",
+	Short: "Open BlueFunda signup page in your browser",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		signupURL := "https://bluefunda.com/signup?utm_source=cli&utm_medium=command&utm_campaign=signup"
+		fmt.Printf("Opening signup page: %s\n", signupURL)
+		if err := openBrowser(signupURL); err != nil {
+			fmt.Printf("Could not open browser. Please visit the URL above manually.\n")
+		}
+		go client.Track("signup_opened", nil)
+		return nil
+	},
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	DefaultBaseURL = "https://api.bluefunda.com"
-	DefaultRealm   = "trm"
+	DefaultRealm   = "individual"
 	ClientID       = "cai-cli"
 	ConfigDir      = ".abaper"
 	ConfigFile     = "config"


### PR DESCRIPTION
## Summary
- Update auth to use `individual` realm on `ai.bluefunda.com` (was `trm` on `auth.bluefunda.com`)
- Route login through `bluefunda.com/login` with UTM params for GA attribution
- Add `abaper signup` command opening `bluefunda.com/signup`
- Add telemetry client posting events to `/abaper/telemetry` (Prometheus via abaper-bff)
- Track: `cli_invoked` (every command), `login_started`, `login_completed`, `logout`, `signup_opened`, `chat_opened`

## Related PRs
- bluefunda/abaper-bff#14 (telemetry endpoint)
- bluefunda/abaper-gw#12 (gateway route)
- bluefunda/abaper-vscode#3 (same features for VS Code extension)
- bluefunda/bluefunda.com#45 (login/signup page redirect support)

## Test plan
- [ ] `abaper login` opens `bluefunda.com/login?redirect_uri=...&utm_source=cli`
- [ ] `abaper signup` opens `bluefunda.com/signup?utm_source=cli`
- [ ] `abaper ai chat "hello"` fires `chat_opened` telemetry event
- [ ] All commands fire `cli_invoked` telemetry event

🤖 Generated with [Claude Code](https://claude.com/claude-code)