### PR TITLE
fix: revert auth host to auth.bluefunda.com

### DIFF
--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -33,7 +33,7 @@ type AuthErrorResponse struct {
 }
 
 func authBaseURL(realm string) string {
-	return fmt.Sprintf("https://ai.bluefunda.com/realms/%s/protocol/openid-connect", realm)
+	return fmt.Sprintf("https://auth.bluefunda.com/realms/%s/protocol/openid-connect", realm)
 }
 
 func RequestDeviceCode(realm string) (*DeviceAuthResponse, error) {


### PR DESCRIPTION
## Summary
- Fix login broken by incorrect auth host change
- `ai.bluefunda.com` serves the React SPA, not Keycloak — returns HTML causing JSON parse error
- Revert to `auth.bluefunda.com` (correct Keycloak host), keep `individual` realm (correct)

## Test plan
- [ ] `abaper login` opens Keycloak device verification page
- [ ] No more HTML parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)