### PR TITLE
ci: push Docker image to ghcr.io in addition to Docker Hub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,6 +53,9 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -68,6 +71,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
@@ -78,6 +88,8 @@ jobs:
           tags: |
             bluefunda/abaper:${{ needs.release-please.outputs.tag_name }}
             bluefunda/abaper:latest
+            ghcr.io/bluefunda/abaper:${{ needs.release-please.outputs.tag_name }}
+            ghcr.io/bluefunda/abaper:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary
- Adds ghcr.io login step to the `docker` job
- Pushes image to both `bluefunda/abaper` (Docker Hub) and `ghcr.io/bluefunda/abaper` (GHCR)
- Adds `packages: write` permission to the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)