### PR TITLE
fix: correct docker image name from abaper to abaper-cli

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -34,7 +34,7 @@ jobs:
           build-args: |
             VERSION=${{ inputs.tag }}
           tags: |
-            bluefunda/abaper:${{ inputs.tag }}
-            bluefunda/abaper:latest
+            bluefunda/abaper-cli:${{ inputs.tag }}
+            bluefunda/abaper-cli:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,10 +86,10 @@ jobs:
           build-args: |
             VERSION=${{ needs.release-please.outputs.tag_name }}
           tags: |
-            bluefunda/abaper:${{ needs.release-please.outputs.tag_name }}
-            bluefunda/abaper:latest
-            ghcr.io/bluefunda/abaper:${{ needs.release-please.outputs.tag_name }}
-            ghcr.io/bluefunda/abaper:latest
+            bluefunda/abaper-cli:${{ needs.release-please.outputs.tag_name }}
+            bluefunda/abaper-cli:latest
+            ghcr.io/bluefunda/abaper-cli:${{ needs.release-please.outputs.tag_name }}
+            ghcr.io/bluefunda/abaper-cli:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -105,6 +105,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: bluefunda/abaper
+          repository: bluefunda/abaper-cli
           readme-filepath: ./README.md
           short-description: "ABAPer CLI — command line interface for the ABAPer platform"


### PR DESCRIPTION
## Summary

- Release workflow was pushing Docker images to `bluefunda/abaper` and `ghcr.io/bluefunda/abaper` — the wrong repo/package
- Corrected to `bluefunda/abaper-cli` and `ghcr.io/bluefunda/abaper-cli` in both `release.yaml` and `docker.yaml`
- Also fixed the Docker Hub readme sync target from `bluefunda/abaper` to `bluefunda/abaper-cli`

The 403 on ghcr.io was caused by the `abaper-cli` workflow trying to push to the `abaper` package namespace, which is owned by the `abaper` repo — the `GITHUB_TOKEN` from `abaper-cli` doesn't have write access there.

## Test plan

- [ ] Merge and trigger a release — docker job should push to the correct `abaper-cli` namespace
- [ ] Verify image appears at `ghcr.io/bluefunda/abaper-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)