### PR TITLE
ci: add manual docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,19 @@
+name: Manual Docker Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag (e.g. v2.0.0)
+        default: latest
+        required: false
+        type: string
+
+jobs:
+  deploy:
+    uses: bluefunda/release-foundry/.github/workflows/docker-deploy.yml@main
+    with:
+      tag: ${{ inputs.tag || 'latest' }}
+      build-args: VERSION=${{ inputs.tag || 'latest' }}
+    secrets:
+      GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Adds `docker-build.yml` matching the release-foundry pattern, so Docker images can be triggered manually (e.g. for workflow_dispatch releases that skip the auto docker job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)