### PR TITLE
fix: add packages:write permission to docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      contents: read
+      packages: write
     uses: bluefunda/release-foundry/.github/workflows/docker-deploy.yml@main
     with:
       tag: ${{ inputs.tag || 'latest' }}


### PR DESCRIPTION
The docker-build workflow was missing the `packages: write` permission, causing the ghcr.io login step to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)