### PR TITLE
ci: use ubuntu-latest runner for docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,5 +18,6 @@ jobs:
     with:
       tag: ${{ inputs.tag || 'latest' }}
       build-args: VERSION=${{ inputs.tag || 'latest' }}
+      runner: ubuntu-latest
     secrets:
       GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
     with:
       tag: ${{ needs.release.outputs.tag_name }}
       build-args: VERSION=${{ needs.release.outputs.tag_name }}
+      runner: ubuntu-latest
     secrets:
       GH_PAT: ${{ secrets.GH_PAT }}
 


### PR DESCRIPTION
Self-hosted runner (`devops` user) has no Docker socket — rootless Docker belongs to `phani` (uid 1000). Docker builds must use `ubuntu-latest` which has Docker pre-installed, matching how `abaper-gw` and other service repos do it.

Fixes both `docker-build.yml` (manual trigger) and `release.yml` (auto on release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)