### PR TITLE
fix: remove private module setup from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
 FROM golang:1.25-alpine AS builder
 
-ARG GH_PAT
-RUN if [ -n "$GH_PAT" ]; then \
-      git config --global url."https://${GH_PAT}@github.com/".insteadOf "https://github.com/"; \
-    fi
-
 WORKDIR /app
 COPY go.mod go.sum ./
-ENV GOPRIVATE=github.com/bluefunda/*
 RUN go mod download
 
 COPY . .


### PR DESCRIPTION
golang:1.25-alpine does not include `git`, causing the GH_PAT block to fail with exit code 127. Since abaper has no private bluefunda dependencies (`goprivate` is empty), the block is unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)