### PR TITLE
docs: restructure README around the ABAPer ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,42 @@
 # ABAPer
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/bluefunda/abaper.svg)](https://pkg.go.dev/github.com/bluefunda/abaper)
+[![CI](https://github.com/bluefunda/abaper/actions/workflows/ci.yml/badge.svg)](https://github.com/bluefunda/abaper/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-Command line interface and Go SDK for the [ABAPer](https://abaper.bluefunda.com) platform — generate, deploy, and test ABAP objects directly from your terminal, and a reusable Go library for SAP ABAP development tooling.
+**CLI, TUI, and Go SDK** for the [ABAPer](https://abaper.bluefunda.com) platform — develop, deploy, and test ABAP objects from your terminal, automate SAP workflows in Go, or embed the LSP server in any editor.
+
+## The ABAPer Ecosystem
+
+ABAPer is available across multiple surfaces. All share the same backend and AI capabilities.
+
+| Client | Repo | Best for |
+|--------|------|----------|
+| **Web IDE** | [abaper-editor](https://github.com/bluefunda/abaper-editor) | Browser-based editing, no install |
+| **VS Code** | [abaper-vscode](https://github.com/bluefunda/abaper-vscode) | VS Code users |
+| **CLI / TUI** | **this repo** | Terminal workflows, scripting, CI/CD |
+| **Go SDK** | **this repo** (`lib/`) | Embedding in Go programs |
+| **Eclipse** | [abaper-eclipse](https://github.com/bluefunda/abaper-eclipse) | Eclipse / ADT users _(coming soon)_ |
+
+### Feature matrix
+
+| Feature | Web IDE | VS Code | CLI / TUI |
+|---------|:-------:|:-------:|:---------:|
+| AI pair-programmer chat | ✓ | ✓ | ✓ |
+| Generate ABAP | ✓ | ✓ | ✓ |
+| Deploy & activate | ✓ | ✓ | ✓ |
+| Syntax check / LSP | ✓ | ✓ | SDK |
+| Run unit tests | ✓ | ✓ | ✓ |
+| SAP system management | ✓ | ✓ | ✓ |
+| Offline / no browser | — | — | ✓ |
+| CI/CD integration | — | — | ✓ |
+| Embed in Go programs | — | — | ✓ |
+
+---
 
 ## Installation
 
-### One-line installer (macOS and Linux)
+### One-line installer (macOS / Linux)
 
 ```bash
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/bluefunda/abaper/main/install.sh)"
@@ -39,173 +68,121 @@ ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 sudo dnf install "https://github.com/bluefunda/abaper/releases/download/v${VER}/abaper_${VER}_linux_${ARCH}.rpm"
 ```
 
-### From Source
-
-```bash
-go install github.com/bluefunda/abaper/cmd/abaper@latest
-```
-
 ### Docker
 
 ```bash
 docker pull ghcr.io/bluefunda/abaper
-docker run --rm ghcr.io/bluefunda/abaper version
+docker run --rm -v ~/.abaper:/root/.abaper ghcr.io/bluefunda/abaper status
+```
+
+### From source
+
+```bash
+go install github.com/bluefunda/abaper/cmd/abaper@latest
 ```
 
 ### From GitHub Releases
 
 Download the binary for your platform from the [releases page](https://github.com/bluefunda/abaper/releases).
 
-| Platform       | Archive                              |
-|----------------|--------------------------------------|
-| macOS (ARM64)  | `abaper_<version>_darwin_arm64.zip`  |
-| macOS (AMD64)  | `abaper_<version>_darwin_amd64.zip`  |
-| Linux (AMD64)  | `abaper_<version>_linux_amd64.tar.gz` |
-| Linux (ARM64)  | `abaper_<version>_linux_arm64.tar.gz` |
-| Windows (AMD64)| `abaper_<version>_windows_amd64.zip`  |
-| Windows (ARM64)| `abaper_<version>_windows_arm64.zip`  |
+| Platform        | Archive                               |
+|-----------------|---------------------------------------|
+| macOS (ARM64)   | `abaper_<version>_darwin_arm64.zip`   |
+| macOS (AMD64)   | `abaper_<version>_darwin_amd64.zip`   |
+| Linux (AMD64)   | `abaper_<version>_linux_amd64.tar.gz` |
+| Linux (ARM64)   | `abaper_<version>_linux_arm64.tar.gz` |
+| Windows (AMD64) | `abaper_<version>_windows_amd64.zip`  |
+| Windows (ARM64) | `abaper_<version>_windows_arm64.zip`  |
+
+---
 
 ## Quick Start
 
 ```bash
-# Authenticate
+# 1. Authenticate with the ABAPer platform
 abaper login
 
-# Verify connection
-abaper status
+# 2. Connect to your SAP system
+abaper system add --host https://my-sap:44300 -u DEVELOPER -p secret
+abaper system test
 
-# Create and deploy an ABAP program
+# 3. Open the interactive AI chat (TUI)
+abaper
+
+# 4. Or drive commands directly
 abaper generate --type program --name ZMY_REPORT
 abaper deploy --type program --name ZMY_REPORT --source-file report.abap
 ```
 
-## CLI Commands
+---
 
-### `abaper login`
+## CLI Reference
 
-Authenticate with the ABAPer platform using the OAuth2 device authorization flow. Opens a browser window for interactive login. Credentials are stored locally in `~/.abaper/tokens.yaml` with restricted permissions (0600).
+### Authentication
 
 ```bash
-abaper login
+abaper login       # OAuth2 device flow — opens browser
+abaper logout      # Clear stored tokens
+abaper status      # Show auth + API health
 ```
 
-### `abaper logout`
+### SAP System Management
 
-Clear stored credentials by removing the local token file.
+Connect the CLI and AI chat to your SAP system. Credentials are stored at `~/.abaper/systems.json` (0600) and sent as `X-SAP-*` headers on every request so the gateway can initialise the SAP MCP server for AI tools.
 
 ```bash
-abaper logout
+abaper system add --host https://my-sap:44300 -u USER -p PASS
+abaper system add --host https://my-sap:44300 --name "DEV" --client 200 -u USER -p PASS
+abaper system list            # show all systems (● = active)
+abaper system use "DEV"       # switch active system
+abaper system test            # test active system connection
+abaper system test "DEV"      # test a specific system
+abaper system remove "DEV"
 ```
 
-### `abaper status`
+You can also manage systems inside the TUI by typing `/system add`, `/system list`, or `/system edit <name>`.
 
-Show connection and authentication status. Reports the configured base URL, realm, organization, authentication state, and API health.
+### AI Pair-Programmer
 
 ```bash
-abaper status
-abaper status -o json
+abaper                        # interactive TUI (Bubble Tea chat)
+abaper ai chat "Explain SELECT FOR ALL ENTRIES"
+abaper ai chat "Optimise this" --context-file program.abap
+abaper ai chat "What about performance?" --chat-id <id>
 ```
 
-### `abaper generate`
-
-Create ABAP objects on the target SAP system. Supports programs, classes, and interfaces. Accepts source from a file or generates default templates.
+### Object Operations
 
 ```bash
-# Generate with default template
-abaper generate --type program --name ZMY_PROGRAM
-
-# Generate from source file
+# Generate (create on SAP)
+abaper generate --type program --name ZMY_REPORT
 abaper generate --type class --name ZCL_MY_CLASS --source-file my_class.abap
-
-# Generate an interface
 abaper generate --type interface --name ZIF_MY_INTERFACE
-```
 
-**Flags:**
+# Deploy (upload + activate)
+abaper deploy --type program --name ZMY_REPORT --source-file report.abap
 
-| Flag            | Required | Default   | Description                        |
-|-----------------|----------|-----------|------------------------------------|
-| `--name`        | Yes      | —         | Object name                        |
-| `--type`        | No       | `program` | Object type: program, class, interface |
-| `--source-file` | No       | —         | Path to ABAP source file           |
-
-### `abaper deploy`
-
-Upload source code and activate an ABAP object in a single step.
-
-```bash
-abaper deploy --type program --name ZMY_PROGRAM --source-file program.abap
-```
-
-**Flags:**
-
-| Flag            | Required | Default   | Description                        |
-|-----------------|----------|-----------|------------------------------------|
-| `--name`        | Yes      | —         | Object name                        |
-| `--type`        | No       | `program` | Object type: program, class, interface |
-| `--source-file` | Yes      | —         | Path to ABAP source file           |
-
-### `abaper test`
-
-Run ABAP unit tests for an object on the target SAP system.
-
-```bash
+# Test
 abaper test --type class --name ZCL_MY_CLASS
-abaper test --type class --name ZCL_MY_CLASS -o json
-```
 
-### `abaper list objects`
-
-List ABAP objects, optionally filtered by package or type.
-
-```bash
+# List
 abaper list objects --package ZDEV
-abaper list objects --type program
-```
-
-### `abaper list packages`
-
-List contents of an ABAP package.
-
-```bash
 abaper list packages --name ZDEV
 ```
 
-### `abaper ai chat`
+**Object types:** `program`, `class`, `interface`
 
-Send a prompt to the ABAPer AI assistant and stream the response.
+### Global Flags
 
-```bash
-abaper ai chat "Explain SELECT FOR ALL ENTRIES in ABAP"
-abaper ai chat "Optimize this code" --context-file program.abap
-abaper ai chat "What about performance?" --chat-id <previous-chat-id>
-```
+| Flag             | Default                     | Description                   |
+|------------------|-----------------------------|-------------------------------|
+| `--base-url`     | `https://api.bluefunda.com` | ABAPer API gateway URL        |
+| `--realm`        | `trm`                       | Keycloak realm                |
+| `-o`, `--output` | `text`                      | Output format: `text`, `json` |
 
-### `abaper version`
+### Configuration
 
-Print the CLI version.
-
-```bash
-abaper version
-```
-
-## Global Flags
-
-| Flag              | Description                                        |
-|-------------------|----------------------------------------------------|
-| `--base-url`      | ABAPer API base URL (default: `https://api.bluefunda.com`) |
-| `--realm`         | Keycloak realm (default: `trm`)                    |
-| `-o`, `--output`  | Output format: `text`, `json` (default: `text`)    |
-
-## Configuration
-
-Configuration is loaded in the following order of precedence:
-
-1. **CLI flags** — `--base-url`, `--realm`
-2. **Environment variables** — `ABAPER_BASE_URL`, `ABAPER_REALM`, `ABAPER_ORG`
-3. **Config file** — `~/.abaper/config.yaml`
-
-### Config File
+Priority: CLI flags → environment variables → `~/.abaper/config.yaml`
 
 ```yaml
 # ~/.abaper/config.yaml
@@ -214,131 +191,156 @@ realm: trm
 org: default
 ```
 
-### Environment Variables
+| Environment variable | Description             |
+|----------------------|-------------------------|
+| `ABAPER_BASE_URL`    | Override API base URL   |
+| `ABAPER_REALM`       | Override Keycloak realm |
+| `ABAPER_ORG`         | Override organisation   |
 
-| Variable          | Description                |
-|-------------------|----------------------------|
-| `ABAPER_BASE_URL` | Override the API base URL  |
-| `ABAPER_REALM`    | Override the Keycloak realm|
-| `ABAPER_ORG`      | Override the organization  |
+---
 
-## Authentication
+## Go SDK
 
-ABAPer CLI uses the **OAuth2 device authorization flow** via Keycloak:
+Import the SDK to drive SAP ADT operations directly from Go — no ABAPer platform account required.
 
-1. `abaper login` requests a device code from the authorization server
-2. Your browser opens to the verification URL
-3. The CLI polls for authorization completion
-4. Access and refresh tokens are stored locally
+```bash
+go get github.com/bluefunda/abaper/lib
+```
 
-Tokens are **automatically refreshed** when expired.
-
-## SDK Usage
-
-This repo also exports a reusable Go SDK for SAP ABAP development tooling.
-
-### ADT Client (direct SAP connection)
+### Connect to SAP
 
 ```go
 import "github.com/bluefunda/abaper/lib"
 
 client, err := lib.CreateADTClient(
-    "my-sap.example.com:8000",
-    "100",        // SAP client
-    "user",
-    "pass",
+    "https://my-sap.example.com:44300",
+    "100",        // SAP client number
+    "DEVELOPER",
+    "secret",
 )
-if err != nil {
-    log.Fatal(err)
-}
-src, err := client.GetProgram("ZMY_PROGRAM")
 ```
 
+### Read source
+
+```go
+src, err := client.GetProgram(ctx, "ZMY_PROGRAM")
+fmt.Println(src.Source)
+
+cls, err := client.GetClass(ctx, "ZCL_MY_CLASS")
+```
+
+### Write and activate
+
+```go
+err = client.CreateProgram(ctx, "ZMY_PROG", "My program", "$TMP", source)
+result, err := client.ActivateObject(ctx, "PROG", "ZMY_PROG")
+```
+
+### Search
+
+```go
+results, err := client.SearchObjects(ctx, "ZMY_*", []string{"PROG", "CLAS"})
+packages, err := client.ListPackages(ctx, "ZDEV*")
+```
+
+### Key interfaces (`types/adt.go`)
+
+| Interface | Purpose |
+|-----------|---------|
+| `SourceReader` | Read ABAP object source |
+| `SourceWriter` | Create and update objects |
+| `PackageBrowser` | Search packages and objects |
+| `ObjectActivator` | Activate objects, run unit tests |
+| `LangFeatures` | LSP-style syntax check, completion, navigation |
+| `ADTClient` | Full interface — all of the above |
+
 ### LSP Server
+
+Embed SAP language intelligence in any LSP-capable editor:
 
 ```go
 import "github.com/bluefunda/abaper/lsp"
 
-srv := lsp.NewServer(lsp.Config{
-    ActivateOnSave: true,
-})
-srv.RunStdio()
+srv := lsp.NewServer(adtClient, "/path/to/workspace")
+srv.RunStdio()       // stdio transport (most editors)
+// srv.RunTCP(":2087")
 ```
 
-## Man Page
-
-A Unix man page is included with release archives.
-
-```bash
-sudo make install-man
-man abaper
-```
-
-## Docker Usage
-
-```bash
-docker pull ghcr.io/bluefunda/abaper:latest
-docker run --rm -v ~/.abaper:/root/.abaper ghcr.io/bluefunda/abaper status
-```
-
-## Developer Setup
-
-### Prerequisites
-
-- Go 1.25.1+
-- golangci-lint (for linting)
-
-### Build
-
-```bash
-make build          # Build for current platform
-make build-all      # Cross-compile for all platforms
-make test           # Run tests
-make lint           # Run linter
-make vet            # Run go vet
-```
-
-### Docker
-
-```bash
-make docker-build   # Build Docker image
-make docker-run     # Run CLI in container
-```
+---
 
 ## Architecture
 
 ```
-cmd/abaper/         # CLI entry point
+cmd/abaper/          CLI entry point (Cobra)
+tui/                 Bubble Tea TUI — chat + SAP system form
 internal/
-  commands/         # Cobra command definitions
-  client/           # ABAPer gateway HTTP client + OAuth2
-  config/           # Viper-based config management
-  adt/              # ADT HTTP client (direct SAP)
-  lsp/              # LSP server internals
-types/              # Shared ADT types and interfaces
-lsp/                # Public LSP server wrapper
-rest/               # REST API server
-lib/                # Library wrapper for embedding
-pkg/output/         # Output formatting utilities
+  commands/          Cobra subcommands
+  client/            ABAPer gateway HTTP client (OAuth2 + SAP header injection)
+  config/            Config, token, and SAP system storage (~/.abaper/)
+  adt/               Direct SAP ADT REST client
+  lsp/               LSP server internals
+types/               Shared interfaces and ADT data structures
+lsp/                 Public LSP server wrapper
+rest/                REST API server (CLI feature parity, no AI)
+lib/                 Library wrapper for Go embedding
 ```
 
-- **Authentication**: OAuth2 device authorization flow via Keycloak
-- **API Client**: Calls ABAPer APIs through the KrakenD gateway (`abaper-gw`) at `/abaper/api/v1/*`
-- **SDK**: Types and ADT client for direct SAP ADT REST API usage
+**Request flow:**
+
+```
+abaper CLI / TUI
+      │  Bearer token + X-SAP-{Host,Client,User,Password} headers
+      ▼
+abaper-gw  (KrakenD gateway — authenticates, routes, starts SAP MCP server)
+      │
+      ▼
+SAP ADT REST API    ◄── also reachable directly via lib/ (no gateway)
+```
+
+---
+
+## Docker
+
+```bash
+docker pull ghcr.io/bluefunda/abaper:latest
+
+# Persist credentials
+docker run --rm -v ~/.abaper:/root/.abaper ghcr.io/bluefunda/abaper status
+
+# One-off deploy
+docker run --rm \
+  -v ~/.abaper:/root/.abaper \
+  -v $(pwd):/workspace \
+  ghcr.io/bluefunda/abaper deploy \
+    --type program --name ZMY --source-file /workspace/my.abap
+```
+
+---
+
+## Developer Setup
+
+**Prerequisites:** Go 1.25.1+, golangci-lint
+
+```bash
+make build        # build for current platform
+make build-all    # cross-compile for all platforms
+make test         # go test -race ./...
+make lint         # golangci-lint
+make vet          # go vet
+```
+
+---
 
 ## Release Process
 
 Releases are automated via [release-please](https://github.com/googleapis/release-please):
 
-1. Merge PRs with [conventional commit](https://www.conventionalcommits.org/) titles
-2. release-please creates a Release PR with version bump and changelog
-3. Merging the Release PR triggers:
-   - GoReleaser builds multi-platform binaries (named `abaper_<version>_<os>_<arch>`)
-   - Binaries attached to GitHub Release
-   - Docker image pushed to `ghcr.io/bluefunda/abaper`
+1. Merge PRs with [conventional commit](https://www.conventionalcommits.org/) titles (`feat:`, `fix:`, `chore:` …)
+2. release-please opens a Release PR with version bump + changelog
+3. Merging the Release PR triggers GoReleaser → multi-platform binaries + Docker image at `ghcr.io/bluefunda/abaper`
+
+---
 
 ## License
 
-Licensed under the [Apache License 2.0](LICENSE).
-
-Copyright 2025 BlueFunda, Inc.
+[Apache License 2.0](LICENSE) — Copyright 2025 BlueFunda, Inc.


### PR DESCRIPTION
## Summary

- Opens with ecosystem context — a table of all ABAPer clients and a feature matrix, so any reader immediately understands where this repo fits
- Feature matrix compares Web IDE / VS Code / CLI/TUI across all capabilities (AI chat, deploy, LSP, offline, CI/CD, SDK embedding)
- New **SAP System Management** section covering `abaper system add|list|use|test|remove` and the `/system` TUI slash commands added in v1.7.0
- Separated **CLI** and **Go SDK** audiences into distinct sections with their own quick-start code
- Added request-flow diagram (`CLI → gateway → SAP ADT`) and note that `lib/` works without the gateway
- Added CI badge
- Removed outdated `abaper-cli` reference (repo is `abaper`)

## Type
- [x] documentation

## Test Plan
- [ ] Preview renders correctly on GitHub (tables, code blocks, ASCII diagram)
- [ ] All repo links resolve
- [ ] Install commands match current release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)