### PR TITLE
feat: add abaper search command and fix object type filtering

### DIFF
--- a/internal/adt/client.go
+++ b/internal/adt/client.go
@@ -447,6 +447,16 @@ func (c *ADTClientImpl) SearchObjects(ctx context.Context, pattern string, objec
 		url.QueryEscape(pattern),
 		maxResults)
 
+	if len(objectTypes) > 0 {
+		var sb strings.Builder
+		sb.WriteString(searchURL)
+		for _, ot := range objectTypes {
+			sb.WriteString("&objectType=")
+			sb.WriteString(url.QueryEscape(ot))
+		}
+		searchURL = sb.String()
+	}
+
 	req, err := http.NewRequestWithContext(ctx, "GET", searchURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -52,6 +52,7 @@ func init() {
 	rootCmd.AddCommand(aiCmd)
 	rootCmd.AddCommand(testCmd)
 	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(searchCmd)
 	rootCmd.AddCommand(systemCmd)
 }
 

--- a/internal/commands/search.go
+++ b/internal/commands/search.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bluefunda/abaper/internal/client"
+	"github.com/bluefunda/abaper/pkg/output"
+)
+
+var searchCmd = &cobra.Command{
+	Use:   "search <pattern>",
+	Short: "Search ABAP objects by name pattern",
+	Long: `Search for ABAP objects matching a name pattern.
+Use * as a wildcard, e.g. ZMY* to find all objects starting with ZMY.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSearch,
+}
+
+func init() {
+	searchCmd.Flags().StringP("type", "t", "", "Filter by object type (e.g. PROG/P, CLAS/OC, INTF/OI)")
+}
+
+func runSearch(cmd *cobra.Command, args []string) error {
+	pattern := args[0]
+	objectType, _ := cmd.Flags().GetString("type")
+
+	c, err := client.NewClient()
+	if err != nil {
+		return err
+	}
+
+	objects, err := c.SearchObjects(pattern, objectType)
+	if err != nil {
+		return fmt.Errorf("search failed: %w", err)
+	}
+
+	outputFmt, _ := cmd.Flags().GetString("output")
+	if outputFmt == "json" {
+		output.PrintJSON(objects)
+		return nil
+	}
+
+	if len(objects) == 0 {
+		fmt.Printf("No objects found matching %q.\n", pattern)
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "TYPE\tNAME\tDESCRIPTION")
+	for _, obj := range objects {
+		objType, _ := obj["object_type"].(string)
+		objName, _ := obj["object_name"].(string)
+		desc, _ := obj["description"].(string)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", objType, objName, desc)
+	}
+	return w.Flush()
+}

--- a/rest/server/server.go
+++ b/rest/server/server.go
@@ -321,9 +321,8 @@ func (rs *RestServer) searchObjectsHandler(w http.ResponseWriter, r *http.Reques
 	pattern := req.ObjectName
 	var objectTypes []string
 
-	// Convert args to object types
-	for _, arg := range req.Args {
-		objectTypes = append(objectTypes, strings.ToUpper(arg))
+	if req.ObjectType != "" {
+		objectTypes = []string{strings.ToUpper(req.ObjectType)}
 	}
 
 	rs.logger.Info("Searching objects via REST API",


### PR DESCRIPTION
## Summary

- Add `abaper search <pattern>` CLI command with optional `--type` / `-t` flag for object type filtering
- Fix REST server `searchObjectsHandler` reading `req.Args` instead of `req.ObjectType` — type filter was silently dropped on every search request from abaper-editor
- Fix ADT client `SearchObjects` ignoring the `objectTypes` parameter — type was never appended to the SAP ADT quickSearch URL

## Type

- [x] feature
- [x] fix

## Customer Impact

Users can now search ABAP objects directly from the terminal:
\`\`\`bash
abaper search ZMY*
abaper search ZMY* --type PROG/P
abaper search ZCL* -t CLAS/OC -o json
\`\`\`

The web editor search panel now correctly filters by object type when a type filter is selected.

## Test Plan

- [ ] `abaper search Z*` returns objects from the active SAP system
- [ ] `abaper search ZCL* --type CLAS/OC` returns only classes
- [ ] `abaper search ZMY* -o json` produces JSON output
- [ ] `abaper search NOMATCH` prints "No objects found matching..." message
- [ ] abaper-editor SearchPanel type filter now narrows results correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)