### PR TITLE
feat: add /object search and /source preview to TUI

### DIFF
--- a/internal/commands/search.go
+++ b/internal/commands/search.go
@@ -52,8 +52,8 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "TYPE\tNAME\tDESCRIPTION")
 	for _, obj := range objects {
-		objType, _ := obj["object_type"].(string)
-		objName, _ := obj["object_name"].(string)
+		objType, _ := obj["type"].(string)
+		objName, _ := obj["name"].(string)
 		desc, _ := obj["description"].(string)
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", objType, objName, desc)
 	}

--- a/tui/app.go
+++ b/tui/app.go
@@ -111,6 +111,30 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.view = viewSystemForm
 		return m, m.systemForm.Init()
 
+	case slash.SourcePreviewMsg:
+		if msg.Name == "" || msg.ObjectType == "" {
+			m.chat.messages = append(m.chat.messages, chatMessage{
+				kind:    kindSystem,
+				content: "Usage: `/source <name> <type>` — e.g. `/source ZHELLO_PROGRAM PROG/P`",
+			})
+			m.chat.rebuildViewport()
+			return m, nil
+		}
+		m.chat.messages = append(m.chat.messages, chatMessage{
+			kind:    kindSystem,
+			content: fmt.Sprintf("Fetching **%s** (%s)…", msg.Name, msg.ObjectType),
+		})
+		m.chat.rebuildViewport()
+		return m, doGetSource(msg.Name, msg.ObjectType)
+
+	case sourceResultMsg:
+		m.chat.messages = append(m.chat.messages, chatMessage{
+			kind:    kindSystem,
+			content: msg.content,
+		})
+		m.chat.rebuildViewport()
+		return m, nil
+
 	case slash.ObjectSearchMsg:
 		if msg.Pattern == "" {
 			m.chat.messages = append(m.chat.messages, chatMessage{
@@ -213,10 +237,32 @@ func (m *Model) View() string {
 	return m.chat.View()
 }
 
-const helpText = `Commands: /help /clear /object /system /system add /system list /quit
+const helpText = `Commands: /help /clear /source /object /system /system add /system list /quit
 Keys: Enter submit · Shift+Enter newline · Ctrl+C/Esc cancel stream · Tab navigate form · Ctrl+T test connection · Ctrl+S save`
 
 type searchResultMsg struct{ content string }
+type sourceResultMsg struct{ content string }
+
+func doGetSource(name, objectType string) tea.Cmd {
+	return func() tea.Msg {
+		c, err := client.NewClient()
+		if err != nil {
+			return sourceResultMsg{content: "Error: " + err.Error()}
+		}
+		obj, err := c.GetObject(objectType, name)
+		if err != nil {
+			return sourceResultMsg{content: "Error: " + err.Error()}
+		}
+		source, _ := (*obj)["source"].(string)
+		if source == "" {
+			return sourceResultMsg{content: fmt.Sprintf("No source found for **%s** (%s).", name, objectType)}
+		}
+		lines := strings.Count(source, "\n") + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "**%s** (%s) — %d lines  ↑↓ PgUp PgDn to scroll\n\n```abap\n%s\n```", name, objectType, lines, source)
+		return sourceResultMsg{content: sb.String()}
+	}
+}
 
 func doSearch(pattern, objectType string) tea.Cmd {
 	return func() tea.Msg {

--- a/tui/app.go
+++ b/tui/app.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/bluefunda/abaper/internal/client"
 	"github.com/bluefunda/abaper/internal/config"
 	"github.com/bluefunda/abaper/tui/slash"
 )
@@ -110,6 +111,30 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.view = viewSystemForm
 		return m, m.systemForm.Init()
 
+	case slash.ObjectSearchMsg:
+		if msg.Pattern == "" {
+			m.chat.messages = append(m.chat.messages, chatMessage{
+				kind:    kindSystem,
+				content: "Usage: `/object <pattern> [type]` — e.g. `/object ZMY*` or `/object ZCL* CLAS/OC`",
+			})
+			m.chat.rebuildViewport()
+			return m, nil
+		}
+		m.chat.messages = append(m.chat.messages, chatMessage{
+			kind:    kindSystem,
+			content: fmt.Sprintf("Searching for **%s**…", msg.Pattern),
+		})
+		m.chat.rebuildViewport()
+		return m, doSearch(msg.Pattern, msg.ObjectType)
+
+	case searchResultMsg:
+		m.chat.messages = append(m.chat.messages, chatMessage{
+			kind:    kindSystem,
+			content: msg.content,
+		})
+		m.chat.rebuildViewport()
+		return m, nil
+
 	case slash.UnknownCmdMsg:
 		return m, nil
 	}
@@ -188,5 +213,35 @@ func (m *Model) View() string {
 	return m.chat.View()
 }
 
-const helpText = `Commands: /help /clear /system /system add /system list /quit
+const helpText = `Commands: /help /clear /object /system /system add /system list /quit
 Keys: Enter submit · Shift+Enter newline · Ctrl+C/Esc cancel stream · Tab navigate form · Ctrl+T test connection · Ctrl+S save`
+
+type searchResultMsg struct{ content string }
+
+func doSearch(pattern, objectType string) tea.Cmd {
+	return func() tea.Msg {
+		c, err := client.NewClient()
+		if err != nil {
+			return searchResultMsg{content: "Search error: " + err.Error()}
+		}
+		objects, err := c.SearchObjects(pattern, objectType)
+		if err != nil {
+			return searchResultMsg{content: "Search error: " + err.Error()}
+		}
+		if len(objects) == 0 {
+			return searchResultMsg{content: fmt.Sprintf("No objects found matching **%s**.", pattern)}
+		}
+
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "**Search results for %s** (%d)\n\n", pattern, len(objects))
+		sb.WriteString("| TYPE | NAME | DESCRIPTION |\n")
+		sb.WriteString("|------|------|-------------|\n")
+		for _, obj := range objects {
+			objType, _ := obj["type"].(string)
+			objName, _ := obj["name"].(string)
+			desc, _ := obj["description"].(string)
+			fmt.Fprintf(&sb, "| %s | %s | %s |\n", objType, objName, desc)
+		}
+		return searchResultMsg{content: sb.String()}
+	}
+}

--- a/tui/slash/commands.go
+++ b/tui/slash/commands.go
@@ -15,6 +15,14 @@ type HelpMsg struct{}
 // EditID is empty for "add", or a system ID/name for "edit".
 type SystemOpenMsg struct{ EditID string }
 
+// ObjectSearchMsg tells the app to search for ABAP objects.
+// Pattern is the search pattern (SAP wildcards, e.g. ZMY*).
+// ObjectType is optional, e.g. "PROG/P", "CLAS/OC".
+type ObjectSearchMsg struct {
+	Pattern    string
+	ObjectType string
+}
+
 // UnknownCmdMsg is returned when a slash command is not found.
 type UnknownCmdMsg struct{ Name string }
 
@@ -70,8 +78,18 @@ var Registry = []Command{
 	},
 	{
 		Name:        "object",
-		Description: "Load ABAP object from SAP",
-		Handler:     func(_ []string) tea.Cmd { return nil },
+		Description: "Search ABAP objects: /object <pattern> [type], e.g. /object ZMY* PROG/P",
+		Handler: func(args []string) tea.Cmd {
+			pattern := ""
+			objType := ""
+			if len(args) > 0 {
+				pattern = args[0]
+			}
+			if len(args) > 1 {
+				objType = args[1]
+			}
+			return func() tea.Msg { return ObjectSearchMsg{Pattern: pattern, ObjectType: objType} }
+		},
 	},
 	{
 		Name:        "activate",

--- a/tui/slash/commands.go
+++ b/tui/slash/commands.go
@@ -23,6 +23,12 @@ type ObjectSearchMsg struct {
 	ObjectType string
 }
 
+// SourcePreviewMsg tells the app to fetch and display an object's source.
+type SourcePreviewMsg struct {
+	Name       string
+	ObjectType string
+}
+
 // UnknownCmdMsg is returned when a slash command is not found.
 type UnknownCmdMsg struct{ Name string }
 
@@ -75,6 +81,21 @@ var Registry = []Command{
 		Name:        "compact",
 		Description: "Summarize & compress context",
 		Handler:     func(_ []string) tea.Cmd { return nil },
+	},
+	{
+		Name:        "source",
+		Description: "Preview object source: /source <name> <type>, e.g. /source ZHELLO PROG/P",
+		Handler: func(args []string) tea.Cmd {
+			name := ""
+			objType := ""
+			if len(args) > 0 {
+				name = args[0]
+			}
+			if len(args) > 1 {
+				objType = args[1]
+			}
+			return func() tea.Msg { return SourcePreviewMsg{Name: name, ObjectType: objType} }
+		},
 	},
 	{
 		Name:        "object",

--- a/tui/slash/menu.go
+++ b/tui/slash/menu.go
@@ -39,14 +39,18 @@ func (m *MenuModel) Height() int {
 }
 
 func (m *MenuModel) refilter() {
-	if m.filter == "" {
+	// Only match on the command name (first word); the rest is args.
+	word := ""
+	if parts := strings.Fields(m.filter); len(parts) > 0 {
+		word = strings.ToLower(parts[0])
+	}
+	if word == "" {
 		m.filtered = Registry
 	} else {
-		q := strings.ToLower(m.filter)
 		var out []Command
 		for _, c := range Registry {
-			if strings.Contains(strings.ToLower(c.Name), q) ||
-				strings.Contains(strings.ToLower(c.Description), q) {
+			if strings.Contains(strings.ToLower(c.Name), word) ||
+				strings.Contains(strings.ToLower(c.Description), word) {
 				out = append(out, c)
 			}
 		}
@@ -102,6 +106,10 @@ func (m *MenuModel) Update(msg tea.Msg) (*MenuModel, tea.Cmd) {
 			m.refilter()
 		}
 
+	case tea.KeySpace:
+		m.filter += " "
+		m.refilter()
+
 	case tea.KeyRunes:
 		m.filter += string(keyMsg.Runes)
 		m.refilter()
@@ -112,10 +120,7 @@ func (m *MenuModel) Update(msg tea.Msg) (*MenuModel, tea.Cmd) {
 
 // View renders the slash menu as a bordered popup.
 func (m *MenuModel) View() string {
-	w := m.width
-	if w < 42 {
-		w = 42
-	}
+	w := max(m.width, 42)
 	innerW := w - 4 // account for border + padding
 
 	muted := lipgloss.NewStyle().Foreground(styles.ColorMuted)
@@ -141,7 +146,7 @@ func (m *MenuModel) View() string {
 		for i, cmd := range m.filtered {
 			nameStr := "/" + cmd.Name
 			// Pad name to fixed width for alignment
-			nameCol := nameStr + strings.Repeat(" ", maxInt(0, 14-len(nameStr)))
+			nameCol := nameStr + strings.Repeat(" ", max(0, 14-len(nameStr)))
 			desc := cmd.Description
 
 			if i == m.cursor {
@@ -167,9 +172,3 @@ func (m *MenuModel) View() string {
 		Render(sb.String())
 }
 
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
## Summary

- Fix search result field names (`name`/`type` not `object_name`/`object_type`) — TYPE and NAME columns were blank
- Add `/object <pattern> [type]` slash command: searches ABAP objects, renders results as a markdown table in the chat viewport (async, non-blocking)
- Fix slash menu space key handling — `tea.KeySpace` was not caught, making it impossible to type args like `/object ZMY*`
- Fix slash menu arg-aware filtering — filter now matches on first word only so typing args after a space no longer breaks command matching
- Add `/source <name> <type>` slash command: fetches and renders ABAP source inline with line count and scroll hint; paging via existing viewport keys (↑↓ PgUp PgDn Home End)

## Type

- [x] feature
- [x] fix

## Customer Impact

```
/object ZMY*              → search results table in chat
/object ZCL* CLAS/OC      → filtered by type
/source ZHELLO_PROGRAM PROG/P  → source preview with scroll
```

## Test Plan

- [ ] `/object Z*` shows TYPE/NAME/DESCRIPTION columns populated
- [ ] Typing space after `/object` in the slash menu works
- [ ] `/object ZCL* CLAS/OC` filters results by type
- [ ] `/source <name> <type>` renders source with line count
- [ ] PgUp/PgDn scroll through long source files
- [ ] `/source` with missing args shows usage hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)