### PR TITLE
chore: bump Go to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bluefunda/abaper
 
-go 1.25.1
+go 1.26.0
 
 require (
 	github.com/bluefunda/banner v0.1.0


### PR DESCRIPTION
## Go `1.25.1` → `1.26.0`

### Changes
- `go.mod`: `go 1.25.1` → `go 1.26.0`

### How CI picks this up
- **Build / test**: `go-ci.yml` reads `go-version-file: go.mod` — no workflow changes needed
- **Docker**: `docker-deploy.yml` extracts `GO_VERSION` from `go.mod` and injects it as `ARG GO_VERSION` at build time

### Release notes
https://go.dev/doc/go1.26

### Checklist
- [ ] CI passes
- [ ] No breaking changes in this service's code

---
Automated by [`bump-go-version.sh`](https://github.com/bluefunda/infra/blob/main/go-standards/bump-go-version.sh).