### PR TITLE
chore: add .claude/commands slash commands

### DIFF
--- a/.claude/commands/plan-issue.md
+++ b/.claude/commands/plan-issue.md
@@ -1,0 +1,13 @@
+---
+description: Read a GitHub issue and produce a plan (no edits)
+argument-hint: [issue-number]
+allowed-tools: Bash(gh issue view:*), Read, Grep, Glob
+---
+Issue:
+!`gh issue view $ARGUMENTS 2>/dev/null`
+
+Read the issue above and this repo's CLAUDE.md, then:
+1. Restate the outcome and acceptance criteria in your own words.
+2. List any ambiguities or decisions you need from me.
+3. Propose a step-by-step plan: files to change, order, tests to add.
+Do NOT edit any files. Wait for my approval.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,11 @@
+---
+description: Build, test, and self-review the current change
+allowed-tools: Bash, Read, Grep, Glob
+---
+Current change:
+!`git diff main...HEAD --stat`
+
+1. Run the project's build and tests (see CLAUDE.md / Makefile).
+2. Check the diff against the linked issue's acceptance criteria — mark each met / not met.
+3. Flag anything risky, out-of-scope, or untested.
+Give a concise PASS/FAIL summary.

--- a/.claude/commands/work-issue.md
+++ b/.claude/commands/work-issue.md
@@ -1,0 +1,13 @@
+---
+description: Implement a GitHub issue end to end
+argument-hint: [issue-number]
+---
+Issue:
+!`gh issue view $ARGUMENTS 2>/dev/null`
+
+Implement this issue against its acceptance criteria.
+- Stay within "In scope"; respect "Out of scope".
+- Small commits, Conventional Commits, referencing (#$ARGUMENTS).
+- Add/update tests.
+- When done, run the "Verify with" commands and report results.
+Stop and ask if you hit a decision the issue doesn't cover.

--- a/.claude/commands/wrap-pr.md
+++ b/.claude/commands/wrap-pr.md
@@ -1,0 +1,8 @@
+---
+description: Open a PR that closes the issue with a release-note-ready summary
+argument-hint: [issue-number]
+allowed-tools: Bash(git:*), Bash(gh pr:*), Read
+---
+Push the current branch and open a PR for issue #$ARGUMENTS:
+- Title: Conventional Commit style.
+- Body: "Closes #$ARGUMENTS", then a one-paragraph plain-English summary suitable for release notes, then the verify results.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,3 +47,13 @@ make vet          # Run go vet
 - Branches: `<type>/<short-description>`
 - PRs: conventional commit title, target `main`, squash-merged
 - Releases: release-please + GoReleaser for multi-platform binaries + Docker image
+
+## How we work (operating rules)
+
+- Every task starts from a GitHub issue. Read it fully first: `gh issue view <N> 2>/dev/null`.
+- M/L issues: produce a short plan and WAIT for approval before editing. S: proceed.
+- Respect the issue's "Out of scope" — do not refactor or touch anything outside it.
+- Commit in small steps, Conventional Commits, referencing the issue: `feat(abaper): ... (#<N>)`.
+- Before claiming done: run the issue's "Verify with" commands; confirm every acceptance box.
+- Open the PR with "Closes #<N>" + a one-paragraph, release-note-ready summary.
+- Secrets come from Vault/env, never hardcoded. Never run destructive git/deploy without asking.


### PR DESCRIPTION
## Summary
Adds four repo-level slash commands under `.claude/commands/` based on the BlueFunda Developer Operating Handbook SOP, and appends the "How we work" operating rules to `CLAUDE.md`. Also fixes `/plan-issue` failing due to `gh issue view` writing a GitHub Projects (classic) deprecation warning to stderr, which the `!` shell substitution incorrectly treated as a command failure.

## Type
- [ ] feature
- [ ] fix
- [ ] performance
- [ ] security
- [x] infrastructure

## Customer Impact


## Metrics

## Marketing Notes

## Test Plan
- [x] `/plan-issue <N>` — confirmed `gh issue view` stderr no longer breaks the command
- [x] All four commands present and load in Claude Code (`/plan-issue`, `/work-issue`, `/verify`, `/wrap-pr`)
- [x] `CLAUDE.md` contains "How we work" block