### PR TITLE
fix(ci): remove unsupported continue-on-error from release-notes job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
   release-notes:
     needs: [release, goreleaser]
     if: ${{ needs.release.outputs.release_created }}
-    continue-on-error: true
     uses: bluefunda/release-foundry/.github/workflows/github-release-notes.yml@main
     with:
       tag: ${{ needs.release.outputs.tag_name }}


### PR DESCRIPTION
## Summary
Removes `continue-on-error: true` from the `release-notes` job in `release.yml`. This property is not supported on jobs that use reusable workflows (`uses:`). GitHub's schema validator treats the job as a regular job when it sees `continue-on-error`, then fails because `runs-on` is missing and `uses`/`with`/`secrets` are unexpected. The release workflow has been failing on every push to main since commit `4ba1210`.

## Type
- [ ] feature
- [x] fix
- [ ] performance
- [ ] security
- [ ] infrastructure

## Customer Impact

## Metrics

## Marketing Notes

## Test Plan
- [x] YAML schema validates locally (no `continue-on-error` on `uses:` jobs)
- [ ] CI green after merge