### PR TITLE
fix(commands): use 2>&1 instead of 2>/dev/null in plan and work

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -4,7 +4,7 @@ argument-hint: [issue-number]
 allowed-tools: Bash(gh issue view:*), Read, Grep, Glob
 ---
 Issue:
-!`gh issue view $ARGUMENTS 2>/dev/null`
+!`gh issue view $ARGUMENTS 2>&1`
 
 Read the issue above and this repo's CLAUDE.md, then:
 1. Restate the outcome and acceptance criteria in your own words.

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -3,7 +3,7 @@ description: Implement a GitHub issue end to end
 argument-hint: [issue-number]
 ---
 Issue:
-!`gh issue view $ARGUMENTS 2>/dev/null`
+!`gh issue view $ARGUMENTS 2>&1`
 
 Implement this issue against its acceptance criteria.
 - Stay within "In scope"; respect "Out of scope".


### PR DESCRIPTION
## Summary
Changes `2>/dev/null` to `2>&1` in the `gh issue view` calls inside `/plan` and `/work`. Silent stderr suppression was causing `gh` failures (no git repo context, auth errors, etc.) to produce an empty issue block — Claude had nothing to work with and did nothing. With `2>&1`, any `gh` error surfaces as visible text so Claude can explain what went wrong instead of silently failing.

## Type
- [ ] feature
- [x] fix
- [ ] performance
- [ ] security
- [ ] infrastructure

## Customer Impact

## Metrics

## Marketing Notes

## Test Plan
- [x] `/plan 51` in a fresh session shows issue content (not silent failure)
- [x] GraphQL deprecation warning passes through to Claude context but doesn't break the command