### PR TITLE
feat(adt): add FormatSource (ABAP pretty-printer) to Go ADT SDK

### DIFF
--- a/internal/adt/client.go
+++ b/internal/adt/client.go
@@ -36,6 +36,7 @@ const (
 	programsCreateEndpoint  = "/programs/programs"
 	classesCreateEndpoint   = "/oo/classes"
 	tableContentsEndpoint   = "/z_mcp_abap_adt/z_tablecontent/%s" // Custom service required
+	formatEndpoint          = "/repository/formatters/format"
 )
 
 // ErrNotFound is returned when an ADT object does not exist (HTTP 404).
@@ -2608,4 +2609,38 @@ func (c *ADTClientImpl) GetNavigationTarget(ctx context.Context, objectType, obj
 		Line:       navResp.Line,
 		Column:     navResp.Column,
 	}, nil
+}
+
+func (c *ADTClientImpl) FormatSource(ctx context.Context, source string) (string, error) {
+	if !c.IsAuthenticated() {
+		return "", fmt.Errorf("client not authenticated - call Authenticate() first")
+	}
+
+	url := c.baseURL + formatEndpoint
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(source))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	c.addAuthHeaders(req)
+	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
+	req.Header.Set("Accept", "text/plain")
+
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("format failed: HTTP %d - %s", resp.StatusCode, string(body))
+	}
+
+	return string(body), nil
 }

--- a/types/adt.go
+++ b/types/adt.go
@@ -195,6 +195,7 @@ type LangFeatures interface {
 	SyntaxCheck(ctx context.Context, objectType, objectName, source string) (*SyntaxCheckResult, error)
 	GetCompletionProposals(ctx context.Context, objectType, objectName, source string, line, col int) ([]CompletionProposal, error)
 	GetNavigationTarget(ctx context.Context, objectType, objectName, source string, line, col int) (*NavigationTarget, error)
+	FormatSource(ctx context.Context, source string) (string, error)
 }
 
 // SessionManager controls client lifecycle.


### PR DESCRIPTION
## Summary

Adds `FormatSource(ctx context.Context, source string) (string, error)` to the `LangFeatures` interface and implements it on `ADTClientImpl`. This closes the **P1-1** gap from the ADT parity analysis (`docs/adt-parity.md`) — the `abaper-editor` calls the SAP ADT pretty-printer endpoint today via `abaper-ts`, and this method is required to replace that dependency with the Go SDK.

- Adds `formatEndpoint = "/repository/formatters/format"` constant alongside existing endpoint constants
- Posts raw ABAP source as `text/plain`, returns the formatted source string
- Follows the same auth, retry, and error-handling patterns as all other `ADTClientImpl` methods

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)