### PR TITLE
feat(adt): add GetDDLSource (CDS/DDLS) to Go ADT SDK

### DIFF
--- a/internal/adt/client.go
+++ b/internal/adt/client.go
@@ -31,6 +31,7 @@ const (
 	interfacesEndpoint      = "/oo/interfaces/%s/source/main"
 	domainsEndpoint         = "/ddic/domains/%s/source/main"
 	dataElementsEndpoint    = "/ddic/dataelements/%s"
+	ddlSourcesEndpoint      = "/ddic/ddl/sources/%s/source/main"
 	searchEndpoint = "/repository/informationsystem/search"
 	transactionEndpoint     = "/repository/informationsystem/objectproperties/values"
 	programsCreateEndpoint  = "/programs/programs"
@@ -348,6 +349,11 @@ func (c *ADTClientImpl) GetFunctionGroup(ctx context.Context, functionGroup stri
 		zap.Int("source_length", len(result.Source)))
 
 	return result, nil
+}
+
+// GetDDLSource retrieves CDS / DDL source code.
+func (c *ADTClientImpl) GetDDLSource(ctx context.Context, name string) (*types.ADTSourceCode, error) {
+	return c.getSource(ctx, "DDLS", name, ddlSourcesEndpoint)
 }
 
 // GetInclude retrieves ABAP include source code.
@@ -1602,6 +1608,8 @@ func (c *ADTClientImpl) GetObjectSource(ctx context.Context, objectType, objectN
 		sourcePath = fmt.Sprintf("/programs/includes/%s/source/main", strings.ToLower(objectName))
 	case "INTERFACE":
 		sourcePath = fmt.Sprintf("/oo/interfaces/%s/source/main", strings.ToLower(objectName))
+	case "DDLS", "DATA_DEFINITION":
+		sourcePath = fmt.Sprintf("/ddic/ddl/sources/%s/source/main", strings.ToLower(objectName))
 	default:
 		return "", fmt.Errorf("unsupported object type for source retrieval: %s", objectType)
 	}
@@ -2110,6 +2118,8 @@ func objectTypeToURI(objectType, objectName string) (string, error) {
 		return fmt.Sprintf("/sap/bc/adt/functions/groups/%s", name), nil
 	case "INCL", "INCLUDE":
 		return fmt.Sprintf("/sap/bc/adt/programs/includes/%s", name), nil
+	case "DDLS", "DATA_DEFINITION":
+		return fmt.Sprintf("/sap/bc/adt/ddic/ddl/sources/%s", name), nil
 	default:
 		return "", fmt.Errorf("unsupported object type for activation: %s", objectType)
 	}

--- a/types/adt.go
+++ b/types/adt.go
@@ -174,6 +174,7 @@ type SourceReader interface {
 	GetTable(ctx context.Context, name string) (*ADTSourceCode, error)
 	GetFunction(ctx context.Context, functionName, functionGroup string) (*ADTSourceCode, error)
 	GetFunctionGroup(ctx context.Context, name string) (*ADTSourceCode, error)
+	GetDDLSource(ctx context.Context, name string) (*ADTSourceCode, error)
 	GetObjectSource(ctx context.Context, objectType, objectName string) (string, error)
 	CheckObjectExists(ctx context.Context, objectType, objectName string) (bool, error)
 }


### PR DESCRIPTION
## Summary

Closes the **P1-6** gap from the ADT parity analysis (`docs/adt-parity.md`). `abaper-ts` reads CDS / Data Definition Language source via the `DDLS` object type; the Go SDK previously rejected it as unsupported.

- **`GetDDLSource(ctx, name)`** added to `SourceReader` interface and implemented as a one-liner via the shared `getSource` helper — `GET /sap/bc/adt/ddic/ddl/sources/{NAME}/source/main`
- **`GetObjectSource`** extended with `DDLS` / `DATA_DEFINITION` case so the generic API also works
- **`objectTypeToURI`** extended with the same cases so activation and transport operations work on CDS objects too

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)