### PR TITLE
feat(rest): connection pool with idle eviction + abaper serve command

### DIFF
--- a/internal/commands/serve.go
+++ b/internal/commands/serve.go
@@ -1,0 +1,105 @@
+package commands
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/bluefunda/abaper/internal/config"
+	"github.com/bluefunda/abaper/internal/adt"
+	"github.com/bluefunda/abaper/rest/server"
+	"github.com/bluefunda/abaper/types"
+)
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Start the local ABAPer REST server (abaper-ts replacement)",
+	Long: `Starts a local HTTP server that exposes the ADT SDK over REST,
+mirroring the abaper-ts API surface. Useful for local development and
+integration testing with abaper-editor.
+
+The active SAP system from ~/.abaper/systems.json is used as the default
+connection. Pass --system to select a different one. The server also accepts
+per-request X-SAP-* headers for multi-system operation.`,
+	RunE: runServe,
+}
+
+func init() {
+	serveCmd.Flags().String("port", "8080", "Port to listen on")
+	serveCmd.Flags().String("system", "", "SAP system name or ID to use (default: active system)")
+	serveCmd.Flags().Bool("allow-self-signed", false, "Allow self-signed TLS certificates")
+	rootCmd.AddCommand(serveCmd)
+}
+
+func runServe(cmd *cobra.Command, _ []string) error {
+	port, _ := cmd.Flags().GetString("port")
+	systemName, _ := cmd.Flags().GetString("system")
+	allowSelfSigned, _ := cmd.Flags().GetBool("allow-self-signed")
+
+	// Resolve SAP system from stored config.
+	sysCfg, err := config.LoadSystems()
+	if err != nil {
+		return fmt.Errorf("load systems: %w", err)
+	}
+
+	var sys *config.SAPSystem
+	if systemName != "" {
+		sys = sysCfg.FindByNameOrID(systemName)
+		if sys == nil {
+			return fmt.Errorf("system %q not found — run: abaper system list", systemName)
+		}
+	} else {
+		sys = sysCfg.GetActive()
+		if sys == nil {
+			return fmt.Errorf("no SAP systems configured — run: abaper system add --help")
+		}
+	}
+
+	logger, _ := zap.NewProduction()
+	defer logger.Sync() //nolint:errcheck
+
+	logger.Info("Starting ABAPer REST server",
+		zap.String("port", port),
+		zap.String("sap_host", sys.Host),
+		zap.String("sap_client", sys.Client),
+		zap.String("sap_user", sys.Username))
+
+	adtCfg := types.ADTConfig{
+		Host:            sys.Host,
+		Client:          sys.Client,
+		Username:        sys.Username,
+		Password:        sys.Password,
+		Language:        "EN",
+		AllowSelfSigned: allowSelfSigned,
+	}
+
+	// Build and authenticate the default (static) client.
+	staticClient := adt.NewADTClient(&adtCfg)
+	if err := staticClient.Authenticate(); err != nil {
+		return fmt.Errorf("authenticate %s: %w", sys.Host, err)
+	}
+	logger.Info("Authenticated with SAP system", zap.String("host", sys.Host))
+
+	// Build connection pool (for multi-system requests via X-SAP-* headers).
+	pool := server.NewPool(30*time.Minute, logger)
+	pool.StartEviction(cmd.Context(), 5*time.Minute)
+
+	cfg := &server.Config{
+		ADTHost:         sys.Host,
+		ADTClient:       sys.Client,
+		ADTUsername:     sys.Username,
+		ADTPassword:     sys.Password,
+		AllowSelfSigned: allowSelfSigned,
+	}
+
+	srv := server.NewRestServerWithPool(cfg, logger, pool, staticClient)
+
+	fmt.Printf("ABAPer REST server listening on http://localhost:%s\n", port)
+	fmt.Printf("SAP system: %s (%s, client %s)\n", sys.Name, sys.Host, sys.Client)
+	fmt.Println("Press Ctrl+C to stop.")
+
+	srv.Start(port)
+	return nil
+}

--- a/rest/server/pool.go
+++ b/rest/server/pool.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/bluefunda/abaper/internal/adt"
+	"github.com/bluefunda/abaper/types"
+	"go.uber.org/zap"
+)
+
+const defaultPoolTTL = 30 * time.Minute
+
+// poolKey uniquely identifies an ADT connection (password excluded intentionally).
+func poolKey(host, client, username string) string {
+	return host + "|" + client + "|" + username
+}
+
+type poolEntry struct {
+	client   types.ADTClient
+	lastUsed time.Time
+}
+
+// Pool maintains a set of authenticated ADT clients, one per unique
+// host+client+username tuple, with idle-based eviction.
+type Pool struct {
+	mu      sync.Mutex
+	entries map[string]*poolEntry
+	ttl     time.Duration
+	logger  *zap.Logger
+}
+
+// NewPool creates a Pool with the given idle TTL.
+func NewPool(ttl time.Duration, logger *zap.Logger) *Pool {
+	if ttl <= 0 {
+		ttl = defaultPoolTTL
+	}
+	return &Pool{
+		entries: make(map[string]*poolEntry),
+		ttl:     ttl,
+		logger:  logger.With(zap.String("component", "adt_pool")),
+	}
+}
+
+// Get returns an authenticated ADT client for cfg, creating one if not pooled.
+// On authentication failure the entry is removed so the next call retries.
+func (p *Pool) Get(ctx context.Context, cfg types.ADTConfig) (types.ADTClient, error) {
+	key := poolKey(cfg.Host, cfg.Client, cfg.Username)
+
+	p.mu.Lock()
+	e, ok := p.entries[key]
+	if ok {
+		e.lastUsed = time.Now()
+		p.mu.Unlock()
+		if e.client.IsAuthenticated() {
+			return e.client, nil
+		}
+		// Session expired — re-authenticate in place.
+		if err := e.client.Authenticate(); err != nil {
+			p.mu.Lock()
+			delete(p.entries, key)
+			p.mu.Unlock()
+			return nil, fmt.Errorf("re-authenticate %s: %w", cfg.Host, err)
+		}
+		return e.client, nil
+	}
+	p.mu.Unlock()
+
+	// Create and authenticate a new client outside the lock.
+	c := adt.NewADTClient(&cfg)
+	if err := c.Authenticate(); err != nil {
+		return nil, fmt.Errorf("authenticate %s: %w", cfg.Host, err)
+	}
+
+	p.mu.Lock()
+	p.entries[key] = &poolEntry{client: c, lastUsed: time.Now()}
+	p.mu.Unlock()
+
+	p.logger.Info("ADT client added to pool",
+		zap.String("host", cfg.Host),
+		zap.String("sap_client", cfg.Client),
+		zap.String("username", cfg.Username))
+	return c, nil
+}
+
+// EvictIdle removes pool entries that have not been used within the TTL.
+func (p *Pool) EvictIdle() {
+	cutoff := time.Now().Add(-p.ttl)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for key, e := range p.entries {
+		if e.lastUsed.Before(cutoff) {
+			delete(p.entries, key)
+			p.logger.Info("Evicted idle ADT connection", zap.String("key", key))
+		}
+	}
+}
+
+// StartEviction runs EvictIdle on the given interval until ctx is cancelled.
+func (p *Pool) StartEviction(ctx context.Context, interval time.Duration) {
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				p.EvictIdle()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// Size returns the number of connections currently in the pool.
+func (p *Pool) Size() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.entries)
+}

--- a/rest/server/server.go
+++ b/rest/server/server.go
@@ -14,26 +14,29 @@ import (
 
 // Config represents the application configuration
 type Config struct {
-	APIKey      string
-	ADTHost     string
-	ADTClient   string
-	ADTUsername string
-	ADTPassword string
-	Verbose     bool
-	Quiet       bool
+	APIKey          string
+	ADTHost         string
+	ADTClient       string
+	ADTUsername     string
+	ADTPassword     string
+	AllowSelfSigned bool
+	Verbose         bool
+	Quiet           bool
 }
 
 // RestServer handles REST API requests with CLI feature parity (no AI)
 type RestServer struct {
-	logger        *zap.Logger
-	config        *Config
-	adtClient     types.ADTClient   // Full interface, used for lifecycle methods (IsAuthenticated, TestConnection)
-	sourceReader  types.SourceReader
-	sourceWriter  types.SourceWriter
+	logger         *zap.Logger
+	config         *Config
+	pool           *Pool           // nil when running in single-system mode
+	adtClient      types.ADTClient // static fallback client (single-system mode)
+	sourceReader   types.SourceReader
+	sourceWriter   types.SourceWriter
 	packageBrowser types.PackageBrowser
 }
 
-// NewRestServer creates a new REST server instance with ADT client
+// NewRestServer creates a new REST server instance with a static ADT client.
+// Use NewRestServerWithPool for multi-system support.
 func NewRestServer(config *Config, logger *zap.Logger, adtClient types.ADTClient) *RestServer {
 	return &RestServer{
 		logger:         logger.With(zap.String("component", "rest_server")),
@@ -43,6 +46,53 @@ func NewRestServer(config *Config, logger *zap.Logger, adtClient types.ADTClient
 		sourceWriter:   adtClient,
 		packageBrowser: adtClient,
 	}
+}
+
+// NewRestServerWithPool creates a REST server that selects an ADT client from
+// the pool on each request using X-SAP-* headers, with a static fallback.
+func NewRestServerWithPool(config *Config, logger *zap.Logger, pool *Pool, fallback types.ADTClient) *RestServer {
+	rs := &RestServer{
+		logger:    logger.With(zap.String("component", "rest_server")),
+		config:    config,
+		pool:      pool,
+		adtClient: fallback,
+	}
+	if fallback != nil {
+		rs.sourceReader = fallback
+		rs.sourceWriter = fallback
+		rs.packageBrowser = fallback
+	}
+	return rs
+}
+
+// clientForRequest returns the ADT client to use for this request.
+// If X-SAP-* headers are present and a pool is configured, a pooled client is
+// returned. Otherwise falls back to the static client.
+func (rs *RestServer) clientForRequest(r *http.Request) (types.ADTClient, error) {
+	host := r.Header.Get("X-SAP-Host")
+	sapClient := r.Header.Get("X-SAP-Client")
+	user := r.Header.Get("X-SAP-User")
+	password := r.Header.Get("X-SAP-Password")
+
+	if rs.pool != nil && host != "" && user != "" && password != "" {
+		if sapClient == "" {
+			sapClient = "100"
+		}
+		cfg := types.ADTConfig{
+			Host:            host,
+			Client:          sapClient,
+			Username:        user,
+			Password:        password,
+			Language:        "EN",
+			AllowSelfSigned: rs.config.AllowSelfSigned,
+		}
+		return rs.pool.Get(r.Context(), cfg)
+	}
+
+	if rs.adtClient == nil {
+		return nil, fmt.Errorf("no ADT client configured and no X-SAP-* headers provided")
+	}
+	return rs.adtClient, nil
 }
 
 // Handler returns an http.Handler with all routes registered on a private mux.
@@ -152,8 +202,9 @@ func (rs *RestServer) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !rs.adtClient.IsAuthenticated() {
-		rs.sendError(w, "ADT client not authenticated", http.StatusUnauthorized)
+	c, err := rs.clientForRequest(r)
+	if err != nil {
+		rs.sendError(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
 
@@ -166,30 +217,31 @@ func (rs *RestServer) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	var result any
-	var err error
 
 	switch objectType {
 	case "PROGRAM", "PROG":
-		result, err = rs.sourceReader.GetProgram(ctx, objectName)
+		result, err = c.GetProgram(ctx, objectName)
 	case "CLASS", "CLAS":
-		result, err = rs.sourceReader.GetClass(ctx, objectName)
+		result, err = c.GetClass(ctx, objectName)
 	case "FUNCTION", "FUNC":
 		if len(req.Args) == 0 {
 			rs.sendError(w, "function group required in args for function modules", http.StatusBadRequest)
 			return
 		}
 		functionGroup := strings.ToUpper(req.Args[0])
-		result, err = rs.sourceReader.GetFunction(ctx, objectName, functionGroup)
+		result, err = c.GetFunction(ctx, objectName, functionGroup)
 	case "INCLUDE", "INCL":
-		result, err = rs.sourceReader.GetInclude(ctx, objectName)
+		result, err = c.GetInclude(ctx, objectName)
 	case "INTERFACE", "INTF":
-		result, err = rs.sourceReader.GetInterface(ctx, objectName)
+		result, err = c.GetInterface(ctx, objectName)
 	case "STRUCTURE", "STRU":
-		result, err = rs.sourceReader.GetStructure(ctx, objectName)
+		result, err = c.GetStructure(ctx, objectName)
 	case "TABLE", "TABL":
-		result, err = rs.sourceReader.GetTable(ctx, objectName)
+		result, err = c.GetTable(ctx, objectName)
+	case "DDLS", "DATA_DEFINITION":
+		result, err = c.GetDDLSource(ctx, objectName)
 	case "PACKAGE", "PACK":
-		result, err = rs.packageBrowser.GetPackageContents(ctx, objectName)
+		result, err = c.GetPackageContents(ctx, objectName)
 	default:
 		rs.sendError(w, "unsupported object type: "+objectType, http.StatusBadRequest)
 		return
@@ -221,8 +273,9 @@ func (rs *RestServer) createObjectHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if !rs.adtClient.IsAuthenticated() {
-		rs.sendError(w, "ADT client not authenticated", http.StatusUnauthorized)
+	c, err := rs.clientForRequest(r)
+	if err != nil {
+		rs.sendError(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
 
@@ -248,23 +301,22 @@ func (rs *RestServer) createObjectHandler(w http.ResponseWriter, r *http.Request
 		zap.Int("source_length", len(sourceCode)))
 
 	ctx := r.Context()
-	var err error
 
 	switch objectType {
 	case "PROGRAM", "PROG":
-		err = rs.sourceWriter.CreateProgram(ctx, objectName, description, packageName, sourceCode)
+		err = c.CreateProgram(ctx, objectName, description, packageName, sourceCode)
 	case "CLASS", "CLAS":
-		err = rs.sourceWriter.CreateClass(ctx, objectName, description, packageName, sourceCode)
+		err = c.CreateClass(ctx, objectName, description, packageName, sourceCode)
 	case "INCLUDE", "INCL":
-		err = rs.sourceWriter.CreateInclude(ctx, objectName, description, sourceCode)
+		err = c.CreateInclude(ctx, objectName, description, sourceCode)
 	case "INTERFACE", "INTF":
-		err = rs.sourceWriter.CreateInterface(ctx, objectName, description, sourceCode)
+		err = c.CreateInterface(ctx, objectName, description, sourceCode)
 	case "STRUCTURE", "STRU":
-		err = rs.sourceWriter.CreateStructure(ctx, objectName, description, sourceCode)
+		err = c.CreateStructure(ctx, objectName, description, sourceCode)
 	case "TABLE", "TABL":
-		err = rs.sourceWriter.CreateTable(ctx, objectName, description, sourceCode)
+		err = c.CreateTable(ctx, objectName, description, sourceCode)
 	case "FUNCTIONGROUP", "FUGR":
-		err = rs.sourceWriter.CreateFunctionGroup(ctx, objectName, description, sourceCode)
+		err = c.CreateFunctionGroup(ctx, objectName, description, sourceCode)
 	default:
 		rs.sendError(w, "unsupported object type for creation: "+objectType, http.StatusBadRequest)
 		return
@@ -313,14 +365,14 @@ func (rs *RestServer) searchObjectsHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if !rs.adtClient.IsAuthenticated() {
-		rs.sendError(w, "ADT client not authenticated", http.StatusUnauthorized)
+	c, err := rs.clientForRequest(r)
+	if err != nil {
+		rs.sendError(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
 
 	pattern := req.ObjectName
 	var objectTypes []string
-
 	if req.ObjectType != "" {
 		objectTypes = []string{strings.ToUpper(req.ObjectType)}
 	}
@@ -329,7 +381,7 @@ func (rs *RestServer) searchObjectsHandler(w http.ResponseWriter, r *http.Reques
 		zap.String("pattern", pattern),
 		zap.Strings("types", objectTypes))
 
-	results, err := rs.packageBrowser.SearchObjects(r.Context(), pattern, objectTypes)
+	results, err := c.SearchObjects(r.Context(), pattern, objectTypes)
 	if err != nil {
 		rs.sendError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -356,8 +408,9 @@ func (rs *RestServer) listObjectsHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if !rs.adtClient.IsAuthenticated() {
-		rs.sendError(w, "ADT client not authenticated", http.StatusUnauthorized)
+	c, err := rs.clientForRequest(r)
+	if err != nil {
+		rs.sendError(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
 
@@ -373,7 +426,7 @@ func (rs *RestServer) listObjectsHandler(w http.ResponseWriter, r *http.Request)
 
 	switch listType {
 	case "packages", "package":
-		packages, err := rs.packageBrowser.ListPackages(r.Context(), pattern)
+		packages, err := c.ListPackages(r.Context(), pattern)
 		if err != nil {
 			rs.sendError(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -393,12 +446,13 @@ func (rs *RestServer) connectHandler(w http.ResponseWriter, r *http.Request) {
 
 	rs.logger.Info("Testing ADT connection via REST API")
 
-	if rs.adtClient == nil {
-		rs.sendError(w, "ADT client not configured", http.StatusInternalServerError)
+	c, err := rs.clientForRequest(r)
+	if err != nil {
+		rs.sendError(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
 
-	if err := rs.adtClient.TestConnection(); err != nil {
+	if err := c.TestConnection(); err != nil {
 		rs.logger.Error("ADT connection test failed", zap.Error(err))
 		rs.sendError(w, "Connection failed: "+err.Error(), http.StatusServiceUnavailable)
 		return
@@ -406,7 +460,7 @@ func (rs *RestServer) connectHandler(w http.ResponseWriter, r *http.Request) {
 
 	connectionStatus := map[string]any{
 		"status":        "connected",
-		"authenticated": rs.adtClient.IsAuthenticated(),
+		"authenticated": c.IsAuthenticated(),
 		"timestamp":     time.Now().UTC(),
 		"message":       "ADT connection successful",
 	}
@@ -421,16 +475,26 @@ func (rs *RestServer) healthHandler(w http.ResponseWriter, r *http.Request) {
 		adtStatus = "connected"
 	}
 
+	poolSize := 0
+	if rs.pool != nil {
+		poolSize = rs.pool.Size()
+		if poolSize > 0 {
+			adtStatus = "connected"
+		}
+	}
+
 	health := map[string]any{
-		"status":     "healthy",
-		"timestamp":  time.Now().UTC(),
-		"adt_status": adtStatus,
+		"status":           "healthy",
+		"timestamp":        time.Now().UTC(),
+		"adt_status":       adtStatus,
+		"pool_connections": poolSize,
 		"features": map[string]bool{
 			"quiet_mode_default": true,
 			"file_logging":       true,
 			"adt_integration":    true,
 			"cli_parity":         true,
 			"ai_removed":         true,
+			"connection_pool":    rs.pool != nil,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Closes the **P1-5** gap from the ADT parity analysis (`docs/adt-parity.md`) — the final P1 blocker for replacing `abaper-ts` with the Go SDK.

**`rest/server/pool.go` — ADT connection pool**
- `Pool` keyed on `host|client|username` (password never used as key)
- 30-minute idle TTL; `StartEviction` runs a background goroutine
- `Get` creates + authenticates on cache miss; re-authenticates transparently on expired session
- Goroutine-safe (`sync.Mutex`)

**`rest/server/server.go` — pool-aware REST server**
- `NewRestServerWithPool(cfg, logger, pool, fallback)` — new constructor for multi-system operation; `NewRestServer` unchanged for backward compat
- `clientForRequest(r)` — reads `X-SAP-Host/Client/User/Password` headers → pool lookup; falls back to static client if headers absent
- All five ADT handlers (`getObject`, `createObject`, `searchObjects`, `listObjects`, `connect`) updated to use `clientForRequest`
- `healthHandler` reports `pool_connections` count and `connection_pool` feature flag
- `getObjectHandler` gains `DDLS/DATA_DEFINITION` case (picks up P1-6 for free)

**`internal/commands/serve.go` — new `abaper serve` command**
- Reads active (or `--system`) SAP system from `~/.abaper/systems.json`
- Authenticates a static fallback client at startup
- Creates pool, starts 5-min eviction ticker
- Flags: `--port` (default `8080`), `--system`, `--allow-self-signed`

### Local test workflow (once merged)
```bash
# Register a4h.bluefunda.com once
abaper system add --host https://a4h.bluefunda.com --client 001 -u DEVELOPER -p <pw>

# Start local server
abaper serve --port 8080

# Use the CLI against it
curl http://localhost:8080/health
curl -X POST http://localhost:8080/api/v1/objects/search \
  -H 'Content-Type: application/json' \
  -d '{"object_name":"Z*","object_type":"PROG"}'
```

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)