### PR TITLE
fix(docker): align builder image with go.mod (golang:1.26-alpine)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary

- `go.mod` declares `go 1.26.0` but `Dockerfile` was using `golang:1.25-alpine`
- `go mod download` fails in CI with: `go: go.mod requires go >= 1.26.0 (running go 1.25.11; GOTOOLCHAIN=local)`
- One-line fix: bump builder image to `golang:1.26-alpine`

## Root cause

A prior commit rolled back the Dockerfile builder image to `1.25-alpine` after `go.mod` had already been updated to require `1.26.0`, creating the mismatch. Discovered while unblocking the `abaper` service deployment to the `apps` node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)