### PR TITLE
feat(update): add `abaper update` self-update command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/bluefunda/go-update v0.1.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/bluefunda/banner v0.1.0 h1:VDH0OQIua3VjHb2KcsYLukXupFY+4tpQ1MBEOEFQR+Y=
 github.com/bluefunda/banner v0.1.0/go.mod h1:M5mtbgvRhaWJ++YScYqA1dNnc19WKm3Ne0rDmZoobo4=
+github.com/bluefunda/go-update v0.1.0 h1:/1uT2OUTJpvoPU44BfNYDcW3YI2c+Ktlb7p6+qJaYFY=
+github.com/bluefunda/go-update v0.1.0/go.mod h1:OXECIVc6XVlW22jDsF9g9GyPrj/Maqu5nBBwYii1d5A=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
 github.com/charmbracelet/bubbles v1.0.0/go.mod h1:9d/Zd5GdnauMI5ivUIVisuEm3ave1XwXtD1ckyV6r3E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -54,6 +54,7 @@ func init() {
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(searchCmd)
 	rootCmd.AddCommand(systemCmd)
+	rootCmd.AddCommand(updateCmd)
 }
 
 func Execute() error {

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -1,0 +1,24 @@
+package commands
+
+import (
+	"github.com/bluefunda/go-update"
+	"github.com/spf13/cobra"
+)
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update abaper to the latest version",
+	Long: `Check for a newer release of abaper and upgrade automatically.
+
+The installation method (Homebrew, dpkg, rpm, or standalone binary) is
+detected from the current executable path.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return update.Run(update.Config{
+			BinaryName:     "abaper",
+			CurrentVersion: version,
+			GitHubOwner:    "bluefunda",
+			GitHubRepo:     "abaper",
+			HomebrewCask:   "abaper",
+		})
+	},
+}


### PR DESCRIPTION
## Summary

Adds an `abaper update` subcommand that checks for a newer release on GitHub and upgrades the binary automatically. Uses the shared `github.com/bluefunda/go-update` library to detect the installation method (Homebrew, dpkg, rpm, or standalone binary) from the executable path and invoke the correct upgrade strategy.

## Type
- [x] feature
- [ ] fix
- [ ] performance
- [ ] security
- [ ] infrastructure

## Customer Impact

abaper users can now update to the latest version directly from the CLI without needing to know or remember the correct brew/dpkg/rpm command. Running `abaper update` handles detection and upgrade automatically, regardless of how the CLI was installed.

## Metrics

## Marketing Notes

`abaper update` — upgrade the CLI in one command. No need to remember brew, apt, or rpm syntax. abaper detects how it was installed and upgrades itself automatically.

## Test Plan

- [ ] `abaper update` on an older version detects the version delta and prompts for confirmation
- [ ] Accepting the prompt upgrades to the latest release
- [ ] `abaper update` on the current latest prints "abaper is already up to date"
- [ ] `abaper --help` lists the `update` subcommand
- [ ] `go build ./...` and `go vet ./...` pass cleanly

Closes #74