### PR TITLE
fix(list): repair list objects/packages against REST server

### DIFF
--- a/internal/client/abaper_api.go
+++ b/internal/client/abaper_api.go
@@ -327,7 +327,7 @@ func (c *Client) GatewayVersion() (map[string]string, error) {
 	return result, nil
 }
 
-// ListObjects lists ABAP objects in a package.
+// ListObjects lists ABAP objects in a package, optionally filtered by type.
 func (c *Client) ListObjects(packageName, objectType string) ([]map[string]any, error) {
 	body := map[string]string{}
 	if packageName != "" {
@@ -337,15 +337,11 @@ func (c *Client) ListObjects(packageName, objectType string) ([]map[string]any, 
 		body["object_type"] = objectType
 	}
 
-	type ListResult struct {
-		Objects []map[string]any `json:"Objects"`
-	}
-
-	result, err := Post[ListResult](c, "/api/v1/objects/list", body)
+	result, err := Post[[]map[string]any](c, "/api/v1/objects/list", body)
 	if err != nil {
 		return nil, err
 	}
-	return result.Objects, nil
+	return *result, nil
 }
 
 // RunUnitTests executes ABAP unit tests for an object.
@@ -384,14 +380,15 @@ func (c *Client) Navigation(objectName, objectType, source string, line, column 
 // PackageContents lists the contents of a package.
 func (c *Client) PackageContents(packageName string) ([]map[string]any, error) {
 	body := map[string]string{
-		"package": packageName,
+		"object_type": "package",
+		"object_name": packageName,
 	}
 
 	type PkgResult struct {
-		Objects []map[string]any `json:"Objects"`
+		Objects []map[string]any `json:"objects"`
 	}
 
-	result, err := Post[PkgResult](c, "/api/v1/packages/contents", body)
+	result, err := Post[PkgResult](c, "/api/v1/objects/get", body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -61,10 +61,10 @@ func runListObjects(cmd *cobra.Command, args []string) error {
 		}
 		for _, obj := range objects {
 			parts := []string{}
-			if t, ok := obj["object_type"]; ok {
+			if t, ok := obj["type"]; ok {
 				parts = append(parts, fmt.Sprintf("%v", t))
 			}
-			if n, ok := obj["object_name"]; ok {
+			if n, ok := obj["name"]; ok {
 				parts = append(parts, fmt.Sprintf("%v", n))
 			}
 			fmt.Println(strings.Join(parts, "\t"))
@@ -97,10 +97,10 @@ func runListPackages(cmd *cobra.Command, args []string) error {
 		}
 		for _, obj := range objects {
 			parts := []string{}
-			if t, ok := obj["object_type"]; ok {
+			if t, ok := obj["type"]; ok {
 				parts = append(parts, fmt.Sprintf("%v", t))
 			}
-			if n, ok := obj["object_name"]; ok {
+			if n, ok := obj["name"]; ok {
 				parts = append(parts, fmt.Sprintf("%v", n))
 			}
 			fmt.Println(strings.Join(parts, "\t"))

--- a/rest/server/server.go
+++ b/rest/server/server.go
@@ -401,7 +401,10 @@ func (rs *RestServer) searchObjectsHandler(w http.ResponseWriter, r *http.Reques
 	rs.sendSuccess(w, results)
 }
 
-// listObjectsHandler handles object listing requests (CLI list command equivalent)
+// listObjectsHandler handles object listing requests (CLI list command equivalent).
+// Two modes: object_type=packages/package searches package names by pattern;
+// otherwise package is required and returns that package's contents, optionally
+// filtered by object_type (e.g. "PROG" or "PROG/P").
 func (rs *RestServer) listObjectsHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
 		rs.sendError(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -414,11 +417,6 @@ func (rs *RestServer) listObjectsHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if req.ObjectType == "" {
-		rs.sendError(w, "object_type is required", http.StatusBadRequest)
-		return
-	}
-
 	c, err := rs.clientForRequest(r)
 	if err != nil {
 		rs.sendError(w, err.Error(), http.StatusUnauthorized)
@@ -426,26 +424,51 @@ func (rs *RestServer) listObjectsHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	listType := strings.ToLower(req.ObjectType)
-	pattern := req.ObjectName
-	if pattern == "" {
-		pattern = "*"
-	}
 
-	rs.logger.Info("Listing objects via REST API",
-		zap.String("type", listType),
-		zap.String("pattern", pattern))
-
-	switch listType {
-	case "packages", "package":
+	if listType == "packages" || listType == "package" {
+		pattern := req.ObjectName
+		if pattern == "" {
+			pattern = "*"
+		}
+		rs.logger.Info("Listing packages via REST API", zap.String("pattern", pattern))
 		packages, err := c.ListPackages(r.Context(), pattern)
 		if err != nil {
 			rs.sendError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		rs.sendSuccess(w, packages)
-	default:
-		rs.sendError(w, "unsupported list type: "+listType, http.StatusBadRequest)
+		return
 	}
+
+	if req.Package == "" {
+		rs.sendError(w, "package is required (or object_type=packages to search package names)", http.StatusBadRequest)
+		return
+	}
+
+	rs.logger.Info("Listing package contents via REST API",
+		zap.String("package", req.Package),
+		zap.String("type_filter", req.ObjectType))
+
+	pkg, err := c.GetPackageContents(r.Context(), strings.ToUpper(req.Package))
+	if err != nil {
+		rs.sendError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	objects := pkg.Objects
+	if req.ObjectType != "" {
+		filterType := strings.ToUpper(req.ObjectType)
+		filtered := make([]types.ADTObject, 0, len(objects))
+		for _, obj := range objects {
+			objType := strings.ToUpper(obj.Type)
+			if objType == filterType || strings.HasPrefix(objType, filterType+"/") {
+				filtered = append(filtered, obj)
+			}
+		}
+		objects = filtered
+	}
+
+	rs.sendSuccess(w, objects)
 }
 
 func (rs *RestServer) saveObjectHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- `listObjectsHandler` now honors `--package` and filters `pkg.Objects` by `--type`, instead of ignoring the package filter and only supporting `type=packages`
- `PackageContents` reuses the working `/api/v1/objects/get` route instead of the never-registered `/api/v1/packages/contents`
- `ListObjects` decodes the bare JSON array the server actually returns, instead of an `{"Objects": [...]}` wrapper that never matched
- `list.go` reads the correct `type`/`name` response keys (matching `search.go`'s working implementation) instead of nonexistent `object_type`/`object_name`

Found by live-testing non-AI commands against `abap.bluefunda.com`. Since the deployed backend runs this same `rest/server` code (Komodo stack "abaper" on the apps node), this needs a redeploy after merge to take effect live.

Closes #86

## Test plan

- [x] `make build` / `make vet` pass
- [ ] `abaper list packages --name '$TMP'` returns package contents (was 404)
- [ ] `abaper list objects --package '$TMP'` returns objects (was 400)
- [ ] `abaper list objects --package '$TMP' --type PROG` filters by type
- [ ] Redeploy `abaper` Komodo stack and re-verify against `abap.bluefunda.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)