### PR TITLE
test: add coverage for non-AI commands and REST server

### DIFF
--- a/internal/client/abaper_api.go
+++ b/internal/client/abaper_api.go
@@ -265,7 +265,7 @@ func (c *Client) Activate(objectName, objectType string) (*map[string]any, error
 		"object_name": objectName,
 		"object_type": objectType,
 	}
-	return Post[map[string]any](c, "/api/v1/activate", body)
+	return Post[map[string]any](c, "/api/v1/objects/activate", body)
 }
 
 // SyntaxCheck runs syntax validation on source code.
@@ -394,7 +394,6 @@ func (c *Client) PackageContents(packageName string) ([]map[string]any, error) {
 	}
 	return result.Objects, nil
 }
-
 
 // ChatTitle generates a title for a chat session.
 func (c *Client) ChatTitle(chatID, prompt string) (string, error) {

--- a/internal/client/abaper_api_test.go
+++ b/internal/client/abaper_api_test.go
@@ -1,0 +1,356 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newTestClient(t *testing.T, handler http.HandlerFunc) (*Client, *httptest.Server) {
+	t.Helper()
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return &Client{
+		BaseURL:    ts.URL,
+		Token:      "test-token",
+		Realm:      "test-realm",
+		HTTPClient: ts.Client(),
+	}, ts
+}
+
+func writeAPIResponse(t *testing.T, w http.ResponseWriter, data any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"success": true,
+		"data":    data,
+	})
+}
+
+func TestDo_SetsAuthHeaders(t *testing.T) {
+	var gotAuth, gotRealm, gotPath string
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotRealm = r.Header.Get("X-Realm")
+		gotPath = r.URL.Path
+		writeAPIResponse(t, w, map[string]string{})
+	})
+
+	_, err := Post[map[string]string](c, "/api/v1/health", map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotAuth != "Bearer test-token" {
+		t.Errorf("expected bearer token header, got %q", gotAuth)
+	}
+	if gotRealm != "test-realm" {
+		t.Errorf("expected realm header, got %q", gotRealm)
+	}
+	if gotPath != "/abaper/api/v1/health" {
+		t.Errorf("expected path prefixed with /abaper, got %q", gotPath)
+	}
+}
+
+func TestDo_SetsSAPHeadersWhenConfigured(t *testing.T) {
+	var gotHost string
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Header.Get("X-SAP-Host")
+		writeAPIResponse(t, w, map[string]string{})
+	})
+	c.SAPHost = "https://a4h.example.com"
+	c.SAPClient = "001"
+	c.SAPUser = "developer"
+	c.SAPPassword = "secret"
+
+	if _, err := Post[map[string]string](c, "/api/v1/health", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotHost != "https://a4h.example.com" {
+		t.Errorf("expected X-SAP-Host header, got %q", gotHost)
+	}
+}
+
+func TestDo_RetriesOn5xx(t *testing.T) {
+	attempts := 0
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		writeAPIResponse(t, w, map[string]string{"ok": "true"})
+	})
+	// Speed up retry backoff isn't configurable, so keep this test's attempt
+	// count small (default retry loop is 3 attempts total).
+	if _, err := Post[map[string]string](c, "/api/v1/health", nil); err != nil {
+		t.Fatalf("unexpected error after retries: %v", err)
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestPost_PropagatesAPIError(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"error":   "object_type is required",
+		})
+	})
+	_, err := Post[map[string]string](c, "/api/v1/objects/list", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestListObjects_DecodesBareArrayResponse(t *testing.T) {
+	var gotBody map[string]string
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		if r.URL.Path != "/abaper/api/v1/objects/list" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		writeAPIResponse(t, w, []map[string]any{
+			{"type": "PROG/P", "name": "ZHELLO_WORLD"},
+		})
+	})
+
+	objects, err := c.ListObjects("$TMP", "PROG")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotBody["package"] != "$TMP" || gotBody["object_type"] != "PROG" {
+		t.Errorf("unexpected request body: %+v", gotBody)
+	}
+	if len(objects) != 1 || objects[0]["name"] != "ZHELLO_WORLD" {
+		t.Errorf("unexpected objects: %+v", objects)
+	}
+}
+
+func TestPackageContents_UsesObjectsGetRoute(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]string
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		writeAPIResponse(t, w, map[string]any{
+			"name":    "$TMP",
+			"objects": []map[string]any{{"type": "PROG/P", "name": "ZHELLO_WORLD"}},
+		})
+	})
+
+	objects, err := c.PackageContents("$TMP")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/abaper/api/v1/objects/get" {
+		t.Errorf("expected PackageContents to hit /api/v1/objects/get, got %q", gotPath)
+	}
+	if gotBody["object_type"] != "package" || gotBody["object_name"] != "$TMP" {
+		t.Errorf("unexpected request body: %+v", gotBody)
+	}
+	if len(objects) != 1 || objects[0]["name"] != "ZHELLO_WORLD" {
+		t.Errorf("unexpected objects: %+v", objects)
+	}
+}
+
+func TestSearchObjects(t *testing.T) {
+	var gotBody map[string]string
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		writeAPIResponse(t, w, map[string]any{
+			"Objects": []map[string]any{{"type": "PROG/P", "name": "ZHELLO_WORLD"}},
+		})
+	})
+
+	objects, err := c.SearchObjects("ZHELL*", "PROG/P")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotBody["object_name"] != "ZHELL*" || gotBody["object_type"] != "PROG/P" {
+		t.Errorf("unexpected request body: %+v", gotBody)
+	}
+	if len(objects) != 1 || objects[0]["name"] != "ZHELLO_WORLD" {
+		t.Errorf("unexpected objects: %+v", objects)
+	}
+}
+
+func TestGetObject(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		writeAPIResponse(t, w, map[string]any{"object_name": "ZFOO", "source": "REPORT zfoo."})
+	})
+	obj, err := c.GetObject("program", "ZFOO")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if (*obj)["object_name"] != "ZFOO" {
+		t.Errorf("unexpected object: %+v", *obj)
+	}
+}
+
+func TestCreateObject(t *testing.T) {
+	var gotPath string
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		writeAPIResponse(t, w, map[string]any{"created": true})
+	})
+	if err := c.CreateObject("ZFOO", "program", "REPORT zfoo."); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/abaper/api/v1/objects/create" {
+		t.Errorf("unexpected path: %s", gotPath)
+	}
+}
+
+func TestActivate_UsesObjectsActivateRoute(t *testing.T) {
+	var gotPath string
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		writeAPIResponse(t, w, map[string]any{"success": true})
+	})
+	if _, err := c.Activate("ZFOO", "program"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/abaper/api/v1/objects/activate" {
+		t.Errorf("expected Activate to hit /api/v1/objects/activate, got %q", gotPath)
+	}
+}
+
+func TestSyntaxCheck(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		writeAPIResponse(t, w, map[string]any{"messages": []any{}})
+	})
+	if _, err := c.SyntaxCheck("ZFOO", "program", "REPORT zfoo."); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFormatCode(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		writeAPIResponse(t, w, map[string]string{"source": "REPORT zfoo."})
+	})
+	source, err := c.FormatCode("report zfoo.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if source != "REPORT zfoo." {
+		t.Errorf("unexpected formatted source: %q", source)
+	}
+}
+
+func TestTransportInfo(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/abaper/api/v1/transports/info" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		writeAPIResponse(t, w, map[string]any{"transports": []any{}})
+	})
+	if _, err := c.TransportInfo(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateTransport(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		writeAPIResponse(t, w, map[string]string{"transport": "TR0001"})
+	})
+	number, err := c.CreateTransport("test transport", "$TMP")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if number != "TR0001" {
+		t.Errorf("unexpected transport number: %q", number)
+	}
+}
+
+func TestRunUnitTests(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/abaper/api/v1/unit-tests" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		writeAPIResponse(t, w, map[string]any{"all_passed": true})
+	})
+	if _, err := c.RunUnitTests("ZCL_DEMO", "class"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCompletionAndNavigation(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/abaper/api/v1/completion", "/abaper/api/v1/navigation":
+			writeAPIResponse(t, w, map[string]any{})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	})
+	if _, err := c.Completion("ZFOO", "program", "REPORT zfoo.", 1, 1); err != nil {
+		t.Fatalf("unexpected completion error: %v", err)
+	}
+	if _, err := c.Navigation("ZFOO", "program", "REPORT zfoo.", 1, 1); err != nil {
+		t.Fatalf("unexpected navigation error: %v", err)
+	}
+}
+
+func TestHealthCheck(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/abaper/health" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "healthy"})
+	})
+	result, err := c.HealthCheck()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["status"] != "healthy" {
+		t.Errorf("unexpected health result: %+v", result)
+	}
+}
+
+func TestSystemConnect(t *testing.T) {
+	var gotHost, gotUser string
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Header.Get("X-SAP-Host")
+		gotUser = r.Header.Get("X-SAP-User")
+		w.WriteHeader(http.StatusOK)
+	})
+	err := c.SystemConnect("https://a4h.example.com", "001", "developer", "secret")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotHost != "https://a4h.example.com" || gotUser != "developer" {
+		t.Errorf("unexpected SAP headers: host=%q user=%q", gotHost, gotUser)
+	}
+}
+
+func TestSystemConnect_PropagatesFailure(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"success":false,"error":"invalid credentials"}`))
+	})
+	err := c.SystemConnect("https://a4h.example.com", "001", "developer", "wrong")
+	if err == nil {
+		t.Fatal("expected error for failed connection, got nil")
+	}
+}
+
+func TestGatewayVersion(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/abaper/version" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"features": "CLI and REST Services (No AI)"})
+	})
+	version, err := c.GatewayVersion()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if version["features"] == "" {
+		t.Errorf("unexpected version response: %+v", version)
+	}
+}

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/bluefunda/abaper/internal/client"
@@ -52,26 +54,7 @@ func runListObjects(cmd *cobra.Command, args []string) error {
 	}
 
 	outputFmt, _ := cmd.Flags().GetString("output")
-	if outputFmt == "json" {
-		output.PrintJSON(objects)
-	} else {
-		if len(objects) == 0 {
-			fmt.Println("No objects found.")
-			return nil
-		}
-		for _, obj := range objects {
-			parts := []string{}
-			if t, ok := obj["type"]; ok {
-				parts = append(parts, fmt.Sprintf("%v", t))
-			}
-			if n, ok := obj["name"]; ok {
-				parts = append(parts, fmt.Sprintf("%v", n))
-			}
-			fmt.Println(strings.Join(parts, "\t"))
-		}
-	}
-
-	return nil
+	return printObjectList(os.Stdout, objects, outputFmt, "No objects found.")
 }
 
 func runListPackages(cmd *cobra.Command, args []string) error {
@@ -88,23 +71,31 @@ func runListPackages(cmd *cobra.Command, args []string) error {
 	}
 
 	outputFmt, _ := cmd.Flags().GetString("output")
+	return printObjectList(os.Stdout, objects, outputFmt, "No objects found in package.")
+}
+
+// printObjectList renders a list of ABAP objects (as returned by the ABAPer
+// API — keyed by "type" and "name") in text or JSON form.
+func printObjectList(w io.Writer, objects []map[string]any, outputFmt, emptyMessage string) error {
 	if outputFmt == "json" {
 		output.PrintJSON(objects)
-	} else {
-		if len(objects) == 0 {
-			fmt.Println("No objects found in package.")
-			return nil
+		return nil
+	}
+
+	if len(objects) == 0 {
+		fmt.Fprintln(w, emptyMessage)
+		return nil
+	}
+
+	for _, obj := range objects {
+		parts := []string{}
+		if t, ok := obj["type"]; ok {
+			parts = append(parts, fmt.Sprintf("%v", t))
 		}
-		for _, obj := range objects {
-			parts := []string{}
-			if t, ok := obj["type"]; ok {
-				parts = append(parts, fmt.Sprintf("%v", t))
-			}
-			if n, ok := obj["name"]; ok {
-				parts = append(parts, fmt.Sprintf("%v", n))
-			}
-			fmt.Println(strings.Join(parts, "\t"))
+		if n, ok := obj["name"]; ok {
+			parts = append(parts, fmt.Sprintf("%v", n))
 		}
+		fmt.Fprintln(w, strings.Join(parts, "\t"))
 	}
 
 	return nil

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -83,8 +83,8 @@ func printObjectList(w io.Writer, objects []map[string]any, outputFmt, emptyMess
 	}
 
 	if len(objects) == 0 {
-		fmt.Fprintln(w, emptyMessage)
-		return nil
+		_, err := fmt.Fprintln(w, emptyMessage)
+		return err
 	}
 
 	for _, obj := range objects {
@@ -95,7 +95,9 @@ func printObjectList(w io.Writer, objects []map[string]any, outputFmt, emptyMess
 		if n, ok := obj["name"]; ok {
 			parts = append(parts, fmt.Sprintf("%v", n))
 		}
-		fmt.Fprintln(w, strings.Join(parts, "\t"))
+		if _, err := fmt.Fprintln(w, strings.Join(parts, "\t")); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/commands/list_test.go
+++ b/internal/commands/list_test.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPrintObjectList_UsesTypeAndNameKeys(t *testing.T) {
+	// Regression test: the API returns "type"/"name" keys (see search.go and
+	// rest/server ADTObject json tags), not "object_type"/"object_name".
+	var buf bytes.Buffer
+	objects := []map[string]any{
+		{"type": "PROG/P", "name": "ZHELLO_WORLD", "description": "Hello World"},
+	}
+
+	if err := printObjectList(&buf, objects, "text", "No objects found."); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "PROG/P") || !strings.Contains(got, "ZHELLO_WORLD") {
+		t.Errorf("expected type and name in output, got %q", got)
+	}
+}
+
+func TestPrintObjectList_IgnoresLegacyKeys(t *testing.T) {
+	var buf bytes.Buffer
+	objects := []map[string]any{
+		{"object_type": "PROG/P", "object_name": "ZHELLO_WORLD"},
+	}
+
+	if err := printObjectList(&buf, objects, "text", "No objects found."); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := buf.String(); got != "\n" {
+		t.Errorf("expected blank line for unrecognized keys (guards against reintroducing the old bug), got %q", got)
+	}
+}
+
+func TestPrintObjectList_EmptyShowsMessage(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printObjectList(&buf, nil, "text", "No objects found."); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "No objects found." {
+		t.Errorf("expected empty message, got %q", got)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveLoadClearTokens_RoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if _, err := LoadTokens(); err == nil {
+		t.Fatal("expected error loading tokens before any are saved")
+	}
+
+	tokens := &Tokens{
+		AccessToken:  "access-123",
+		RefreshToken: "refresh-456",
+		ExpiresAt:    1234567890,
+	}
+	if err := SaveTokens(tokens); err != nil {
+		t.Fatalf("save tokens: %v", err)
+	}
+
+	loaded, err := LoadTokens()
+	if err != nil {
+		t.Fatalf("load tokens: %v", err)
+	}
+	if loaded.AccessToken != tokens.AccessToken || loaded.RefreshToken != tokens.RefreshToken || loaded.ExpiresAt != tokens.ExpiresAt {
+		t.Errorf("loaded tokens do not match saved tokens: %+v", loaded)
+	}
+
+	path := filepath.Join(ConfigDirPath(), TokenFile)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat tokens file: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("expected tokens.yaml to be 0600, got %o", info.Mode().Perm())
+	}
+
+	if err := ClearTokens(); err != nil {
+		t.Fatalf("clear tokens: %v", err)
+	}
+	if _, err := LoadTokens(); err == nil {
+		t.Fatal("expected error loading tokens after clearing")
+	}
+}
+
+func TestClearTokens_MissingFileIsNotAnError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := ClearTokens(); err != nil {
+		t.Errorf("expected no error clearing nonexistent tokens, got %v", err)
+	}
+}
+
+func TestConfigDirPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	want := filepath.Join(home, ConfigDir)
+	if got := ConfigDirPath(); got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}

--- a/internal/config/systems_test.go
+++ b/internal/config/systems_test.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAddSystem_SetsDefaultsAndActive(t *testing.T) {
+	cfg := &SystemsConfig{}
+	id := cfg.AddSystem(SAPSystem{Host: "https://abap.example.com", Username: "dev"})
+
+	if id == "" {
+		t.Fatal("expected non-empty ID")
+	}
+	if cfg.Active != id {
+		t.Errorf("expected first system to become active, got active=%q id=%q", cfg.Active, id)
+	}
+	sys := cfg.GetActive()
+	if sys == nil {
+		t.Fatal("expected active system")
+	}
+	if sys.Name != sys.Host {
+		t.Errorf("expected name to default to host, got %q", sys.Name)
+	}
+	if sys.Client != "100" {
+		t.Errorf("expected default client 100, got %q", sys.Client)
+	}
+}
+
+func TestAddSystem_SecondSystemDoesNotStealActive(t *testing.T) {
+	cfg := &SystemsConfig{}
+	first := cfg.AddSystem(SAPSystem{Host: "https://a.example.com"})
+	cfg.AddSystem(SAPSystem{Host: "https://b.example.com"})
+
+	if cfg.Active != first {
+		t.Errorf("expected active to remain the first system, got %q", cfg.Active)
+	}
+}
+
+func TestUpdateSystem(t *testing.T) {
+	cfg := &SystemsConfig{}
+	id := cfg.AddSystem(SAPSystem{Host: "https://a.example.com", Username: "dev"})
+
+	ok := cfg.UpdateSystem(id, SAPSystem{Host: "https://a.example.com", Username: "developer", Client: "001"})
+	if !ok {
+		t.Fatal("expected update to succeed")
+	}
+	sys := cfg.FindByNameOrID(id)
+	if sys == nil || sys.Username != "developer" || sys.Client != "001" {
+		t.Errorf("update did not apply: %+v", sys)
+	}
+
+	if cfg.UpdateSystem("does-not-exist", SAPSystem{}) {
+		t.Error("expected update of unknown ID to fail")
+	}
+}
+
+func TestRemoveSystem_ReassignsActive(t *testing.T) {
+	cfg := &SystemsConfig{}
+	first := cfg.AddSystem(SAPSystem{Host: "https://a.example.com"})
+	second := cfg.AddSystem(SAPSystem{Host: "https://b.example.com"})
+
+	if !cfg.RemoveSystem(first) {
+		t.Fatal("expected removal to succeed")
+	}
+	if cfg.Active != second {
+		t.Errorf("expected active to move to remaining system, got %q", cfg.Active)
+	}
+	if len(cfg.Systems) != 1 {
+		t.Errorf("expected 1 system remaining, got %d", len(cfg.Systems))
+	}
+
+	if !cfg.RemoveSystem(second) {
+		t.Fatal("expected removal of last system to succeed")
+	}
+	if cfg.Active != "" {
+		t.Errorf("expected active to clear when no systems remain, got %q", cfg.Active)
+	}
+
+	if cfg.RemoveSystem("does-not-exist") {
+		t.Error("expected removal of unknown ID to fail")
+	}
+}
+
+func TestFindByNameOrID(t *testing.T) {
+	cfg := &SystemsConfig{}
+	id := cfg.AddSystem(SAPSystem{Name: "a4h", Host: "https://a4h.example.com"})
+
+	for _, query := range []string{id, "a4h", "https://a4h.example.com"} {
+		if cfg.FindByNameOrID(query) == nil {
+			t.Errorf("expected to find system by %q", query)
+		}
+	}
+	if cfg.FindByNameOrID("missing") != nil {
+		t.Error("expected nil for unknown query")
+	}
+}
+
+func TestGetActive_FallsBackToFirst(t *testing.T) {
+	cfg := &SystemsConfig{
+		Systems: []SAPSystem{{ID: "sys-1", Host: "https://a.example.com"}},
+		Active:  "sys-does-not-exist",
+	}
+	active := cfg.GetActive()
+	if active == nil || active.ID != "sys-1" {
+		t.Errorf("expected fallback to first system, got %+v", active)
+	}
+}
+
+func TestGetActive_EmptyConfig(t *testing.T) {
+	cfg := &SystemsConfig{}
+	if cfg.GetActive() != nil {
+		t.Error("expected nil active system for empty config")
+	}
+}
+
+func TestLoadSaveSystems_RoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	loaded, err := LoadSystems()
+	if err != nil {
+		t.Fatalf("expected no error loading missing systems file, got %v", err)
+	}
+	if len(loaded.Systems) != 0 {
+		t.Fatalf("expected empty systems for missing file, got %+v", loaded)
+	}
+
+	cfg := &SystemsConfig{}
+	cfg.AddSystem(SAPSystem{Host: "https://abap.example.com", Client: "001", Username: "developer", Password: "secret"})
+
+	if err := SaveSystems(cfg); err != nil {
+		t.Fatalf("save systems: %v", err)
+	}
+
+	reloaded, err := LoadSystems()
+	if err != nil {
+		t.Fatalf("reload systems: %v", err)
+	}
+	if len(reloaded.Systems) != 1 || reloaded.Systems[0].Host != "https://abap.example.com" {
+		t.Errorf("unexpected reloaded systems: %+v", reloaded.Systems)
+	}
+
+	path := filepath.Join(ConfigDirPath(), systemsFile)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat systems file: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("expected systems.json to be 0600, got %o", info.Mode().Perm())
+	}
+}

--- a/rest/server/fake_adt_client_test.go
+++ b/rest/server/fake_adt_client_test.go
@@ -1,0 +1,208 @@
+package server
+
+import (
+	"context"
+
+	"github.com/bluefunda/abaper/types"
+)
+
+// fakeADTClient is a scriptable stand-in for types.ADTClient used to unit
+// test REST handlers without a live SAP system. Each field defaults to a
+// zero-value success response; tests override only what they need.
+type fakeADTClient struct {
+	authenticated bool
+	testConnErr   error
+
+	getProgramFn         func(ctx context.Context, name string) (*types.ADTSourceCode, error)
+	getPackageContentsFn func(ctx context.Context, name string) (*types.ADTPackage, error)
+	listPackagesFn       func(ctx context.Context, pattern string) ([]types.ADTPackage, error)
+	searchObjectsFn      func(ctx context.Context, pattern string, objectTypes []string) (*types.ADTSearchResult, error)
+	updateProgramFn      func(ctx context.Context, name, source string) error
+	updateClassFn        func(ctx context.Context, name, source string) error
+	createProgramFn      func(ctx context.Context, name, description, packageName, source string) error
+	createClassFn        func(ctx context.Context, name, description, packageName, source string) error
+	activateObjectFn     func(ctx context.Context, objectType, objectName string) (*types.ActivationResult, error)
+	runUnitTestsFn       func(ctx context.Context, objectType, objectName string) (*types.UnitTestResult, error)
+	syntaxCheckFn        func(ctx context.Context, objectType, objectName, source string) (*types.SyntaxCheckResult, error)
+	formatSourceFn       func(ctx context.Context, source string) (string, error)
+	completionFn         func(ctx context.Context, objectType, objectName, source string, line, col int) ([]types.CompletionProposal, error)
+	navigationFn         func(ctx context.Context, objectType, objectName, source string, line, col int) (*types.NavigationTarget, error)
+	transportInfoFn      func(ctx context.Context, objectType, objectName string) (*types.ADTTransportInfo, error)
+	createTransportFn    func(ctx context.Context, objectType, objectName, description, packageName string) (string, error)
+}
+
+func (f *fakeADTClient) Authenticate() error              { return nil }
+func (f *fakeADTClient) IsAuthenticated() bool            { return f.authenticated }
+func (f *fakeADTClient) TestConnection() error            { return f.testConnErr }
+func (f *fakeADTClient) SetSessionType(types.SessionType) {}
+
+func (f *fakeADTClient) GetProgram(ctx context.Context, name string) (*types.ADTSourceCode, error) {
+	if f.getProgramFn != nil {
+		return f.getProgramFn(ctx, name)
+	}
+	return &types.ADTSourceCode{ObjectName: name, ObjectType: "PROGRAM"}, nil
+}
+func (f *fakeADTClient) GetClass(ctx context.Context, name string) (*types.ADTSourceCode, error) {
+	return &types.ADTSourceCode{ObjectName: name, ObjectType: "CLASS"}, nil
+}
+func (f *fakeADTClient) GetInclude(ctx context.Context, name string) (*types.ADTSourceCode, error) {
+	return &types.ADTSourceCode{ObjectName: name, ObjectType: "INCLUDE"}, nil
+}
+func (f *fakeADTClient) GetInterface(ctx context.Context, name string) (*types.ADTSourceCode, error) {
+	return &types.ADTSourceCode{ObjectName: name, ObjectType: "INTERFACE"}, nil
+}
+func (f *fakeADTClient) GetStructure(ctx context.Context, name string) (*types.ADTSourceCode, error) {
+	return &types.ADTSourceCode{ObjectName: name, ObjectType: "STRUCTURE"}, nil
+}
+func (f *fakeADTClient) GetTable(ctx context.Context, name string) (*types.ADTSourceCode, error) {
+	return &types.ADTSourceCode{ObjectName: name, ObjectType: "TABLE"}, nil
+}
+func (f *fakeADTClient) GetFunction(ctx context.Context, functionName, functionGroup string) (*types.ADTSourceCode, error) {
+	return &types.ADTSourceCode{ObjectName: functionName, ObjectType: "FUNCTION"}, nil
+}
+func (f *fakeADTClient) GetFunctionGroup(ctx context.Context, name string) (*types.ADTSourceCode, error) {
+	return &types.ADTSourceCode{ObjectName: name, ObjectType: "FUNCTIONGROUP"}, nil
+}
+func (f *fakeADTClient) GetDDLSource(ctx context.Context, name string) (*types.ADTSourceCode, error) {
+	return &types.ADTSourceCode{ObjectName: name, ObjectType: "DDLS"}, nil
+}
+func (f *fakeADTClient) GetObjectSource(ctx context.Context, objectType, objectName string) (string, error) {
+	return "", nil
+}
+func (f *fakeADTClient) CheckObjectExists(ctx context.Context, objectType, objectName string) (bool, error) {
+	return true, nil
+}
+
+func (f *fakeADTClient) CreateProgram(ctx context.Context, name, description, packageName, source string) error {
+	if f.createProgramFn != nil {
+		return f.createProgramFn(ctx, name, description, packageName, source)
+	}
+	return nil
+}
+func (f *fakeADTClient) CreateClass(ctx context.Context, name, description, packageName, source string) error {
+	if f.createClassFn != nil {
+		return f.createClassFn(ctx, name, description, packageName, source)
+	}
+	return nil
+}
+func (f *fakeADTClient) CreateInclude(ctx context.Context, name, description, source string) error {
+	return nil
+}
+func (f *fakeADTClient) CreateInterface(ctx context.Context, name, description, source string) error {
+	return nil
+}
+func (f *fakeADTClient) CreateStructure(ctx context.Context, name, description, source string) error {
+	return nil
+}
+func (f *fakeADTClient) CreateTable(ctx context.Context, name, description, source string) error {
+	return nil
+}
+func (f *fakeADTClient) CreateFunctionGroup(ctx context.Context, name, description, source string) error {
+	return nil
+}
+func (f *fakeADTClient) UpdateProgram(ctx context.Context, name, source string) error {
+	if f.updateProgramFn != nil {
+		return f.updateProgramFn(ctx, name, source)
+	}
+	return nil
+}
+func (f *fakeADTClient) UpdateClass(ctx context.Context, name, source string) error {
+	if f.updateClassFn != nil {
+		return f.updateClassFn(ctx, name, source)
+	}
+	return nil
+}
+func (f *fakeADTClient) UpdateInclude(ctx context.Context, name, source string) error { return nil }
+func (f *fakeADTClient) UpdateInterface(ctx context.Context, name, source string) error {
+	return nil
+}
+func (f *fakeADTClient) UpdateFunction(ctx context.Context, functionName, functionGroup, source string) error {
+	return nil
+}
+func (f *fakeADTClient) UpdateFunctionGroup(ctx context.Context, name, source string) error {
+	return nil
+}
+
+func (f *fakeADTClient) SearchObjects(ctx context.Context, pattern string, objectTypes []string) (*types.ADTSearchResult, error) {
+	if f.searchObjectsFn != nil {
+		return f.searchObjectsFn(ctx, pattern, objectTypes)
+	}
+	return &types.ADTSearchResult{}, nil
+}
+func (f *fakeADTClient) ListPackages(ctx context.Context, pattern string) ([]types.ADTPackage, error) {
+	if f.listPackagesFn != nil {
+		return f.listPackagesFn(ctx, pattern)
+	}
+	return nil, nil
+}
+func (f *fakeADTClient) GetPackageContents(ctx context.Context, name string) (*types.ADTPackage, error) {
+	if f.getPackageContentsFn != nil {
+		return f.getPackageContentsFn(ctx, name)
+	}
+	return &types.ADTPackage{Name: name}, nil
+}
+
+func (f *fakeADTClient) ActivateObject(ctx context.Context, objectType, objectName string) (*types.ActivationResult, error) {
+	if f.activateObjectFn != nil {
+		return f.activateObjectFn(ctx, objectType, objectName)
+	}
+	return &types.ActivationResult{ObjectName: objectName, ObjectType: objectType, Success: true}, nil
+}
+func (f *fakeADTClient) RunUnitTests(ctx context.Context, objectType, objectName string) (*types.UnitTestResult, error) {
+	if f.runUnitTestsFn != nil {
+		return f.runUnitTestsFn(ctx, objectType, objectName)
+	}
+	return &types.UnitTestResult{ObjectName: objectName, AllPassed: true}, nil
+}
+
+func (f *fakeADTClient) SyntaxCheck(ctx context.Context, objectType, objectName, source string) (*types.SyntaxCheckResult, error) {
+	if f.syntaxCheckFn != nil {
+		return f.syntaxCheckFn(ctx, objectType, objectName, source)
+	}
+	return &types.SyntaxCheckResult{ObjectName: objectName, ObjectType: objectType}, nil
+}
+func (f *fakeADTClient) GetCompletionProposals(ctx context.Context, objectType, objectName, source string, line, col int) ([]types.CompletionProposal, error) {
+	if f.completionFn != nil {
+		return f.completionFn(ctx, objectType, objectName, source, line, col)
+	}
+	return nil, nil
+}
+func (f *fakeADTClient) GetNavigationTarget(ctx context.Context, objectType, objectName, source string, line, col int) (*types.NavigationTarget, error) {
+	if f.navigationFn != nil {
+		return f.navigationFn(ctx, objectType, objectName, source, line, col)
+	}
+	return &types.NavigationTarget{}, nil
+}
+func (f *fakeADTClient) FormatSource(ctx context.Context, source string) (string, error) {
+	if f.formatSourceFn != nil {
+		return f.formatSourceFn(ctx, source)
+	}
+	return source, nil
+}
+
+func (f *fakeADTClient) GetTypeInfo(ctx context.Context, typeName string) (*types.ADTTypeInfo, error) {
+	return &types.ADTTypeInfo{TypeName: typeName}, nil
+}
+func (f *fakeADTClient) GetTransaction(ctx context.Context, transactionName string) (*types.ADTTransactionInfo, error) {
+	return &types.ADTTransactionInfo{TransactionCode: transactionName}, nil
+}
+func (f *fakeADTClient) GetTableContents(ctx context.Context, tableName string, maxRows int) (*types.ADTTableData, error) {
+	return &types.ADTTableData{TableName: tableName}, nil
+}
+func (f *fakeADTClient) GetTransports(ctx context.Context) ([]types.ADTTransport, error) {
+	return nil, nil
+}
+func (f *fakeADTClient) GetTransportInfo(ctx context.Context, objectType, objectName string) (*types.ADTTransportInfo, error) {
+	if f.transportInfoFn != nil {
+		return f.transportInfoFn(ctx, objectType, objectName)
+	}
+	return &types.ADTTransportInfo{ObjectName: objectName}, nil
+}
+func (f *fakeADTClient) CreateTransport(ctx context.Context, objectType, objectName, description, packageName string) (string, error) {
+	if f.createTransportFn != nil {
+		return f.createTransportFn(ctx, objectType, objectName, description, packageName)
+	}
+	return "TR0001", nil
+}
+
+var _ types.ADTClient = (*fakeADTClient)(nil)

--- a/rest/server/server_test.go
+++ b/rest/server/server_test.go
@@ -1,0 +1,564 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bluefunda/abaper/types"
+	"go.uber.org/zap"
+)
+
+func newTestServer(t *testing.T, client types.ADTClient) *RestServer {
+	t.Helper()
+	if client == nil {
+		return NewRestServer(&Config{}, zap.NewNop(), nil)
+	}
+	return NewRestServer(&Config{}, zap.NewNop(), client)
+}
+
+func doJSON(t *testing.T, rs *RestServer, method, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *bytes.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal request body: %v", err)
+		}
+		reader = bytes.NewReader(data)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	rec := httptest.NewRecorder()
+	rs.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeSuccess[T any](t *testing.T, rec *httptest.ResponseRecorder) T {
+	t.Helper()
+	var resp struct {
+		Success bool   `json:"success"`
+		Data    T      `json:"data"`
+		Error   string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (body=%s)", err, rec.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("expected success response, got error: %s", resp.Error)
+	}
+	return resp.Data
+}
+
+func decodeError(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var resp struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (body=%s)", err, rec.Body.String())
+	}
+	if resp.Success {
+		t.Fatalf("expected error response, got success")
+	}
+	return resp.Error
+}
+
+// --- objects/get ---
+
+func TestGetObjectHandler(t *testing.T) {
+	t.Run("program", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/get", map[string]string{
+			"object_type": "program",
+			"object_name": "zhello_world",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		data := decodeSuccess[types.ADTSourceCode](t, rec)
+		if data.ObjectName != "ZHELLO_WORLD" {
+			t.Errorf("expected uppercased object name, got %q", data.ObjectName)
+		}
+	})
+
+	t.Run("package via get route", func(t *testing.T) {
+		fake := &fakeADTClient{
+			getPackageContentsFn: func(ctx context.Context, name string) (*types.ADTPackage, error) {
+				return &types.ADTPackage{Name: name, Objects: []types.ADTObject{{Name: "ZFOO", Type: "PROG/P"}}}, nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/get", map[string]string{
+			"object_type": "package",
+			"object_name": "$tmp",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		data := decodeSuccess[types.ADTPackage](t, rec)
+		if data.Name != "$TMP" {
+			t.Errorf("expected uppercased package name, got %q", data.Name)
+		}
+		if len(data.Objects) != 1 || data.Objects[0].Name != "ZFOO" {
+			t.Errorf("expected one object ZFOO, got %+v", data.Objects)
+		}
+	})
+
+	t.Run("missing fields", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/get", map[string]string{"object_type": "program"})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("unsupported type", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/get", map[string]string{
+			"object_type": "bogus",
+			"object_name": "x",
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", rec.Code)
+		}
+		if got := decodeError(t, rec); got != "unsupported object type: BOGUS" {
+			t.Errorf("unexpected error message: %q", got)
+		}
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodGet, "/api/v1/objects/get", nil)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("expected 405, got %d", rec.Code)
+		}
+	})
+
+	t.Run("no client configured", func(t *testing.T) {
+		rs := newTestServer(t, nil)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/get", map[string]string{
+			"object_type": "program",
+			"object_name": "x",
+		})
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+// --- objects/create ---
+
+func TestCreateObjectHandler(t *testing.T) {
+	t.Run("program with default package", func(t *testing.T) {
+		var gotPackage string
+		fake := &fakeADTClient{
+			createProgramFn: func(ctx context.Context, name, description, packageName, source string) error {
+				gotPackage = packageName
+				return nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/create", map[string]string{
+			"object_type": "program",
+			"object_name": "zfoo",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if gotPackage != "$TMP" {
+			t.Errorf("expected default package $TMP, got %q", gotPackage)
+		}
+	})
+
+	t.Run("unsupported type", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/create", map[string]string{
+			"object_type": "function",
+			"object_name": "x",
+		})
+		// FUNCTION has no creation case in the handler switch (only update).
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+// --- objects/save ---
+
+func TestSaveObjectHandler(t *testing.T) {
+	t.Run("updates class", func(t *testing.T) {
+		var gotSource string
+		fake := &fakeADTClient{
+			updateClassFn: func(ctx context.Context, name, source string) error {
+				gotSource = source
+				return nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/save", map[string]string{
+			"object_type": "class",
+			"object_name": "zcl_demo",
+			"source":      "CLASS zcl_demo DEFINITION.",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if gotSource != "CLASS zcl_demo DEFINITION." {
+			t.Errorf("unexpected source passed through: %q", gotSource)
+		}
+	})
+
+	t.Run("missing source", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/save", map[string]string{
+			"object_type": "class",
+			"object_name": "zcl_demo",
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", rec.Code)
+		}
+	})
+}
+
+// --- objects/search ---
+
+func TestSearchObjectsHandler(t *testing.T) {
+	t.Run("returns matches", func(t *testing.T) {
+		fake := &fakeADTClient{
+			searchObjectsFn: func(ctx context.Context, pattern string, objectTypes []string) (*types.ADTSearchResult, error) {
+				if pattern != "ZHELL*" {
+					t.Errorf("unexpected pattern: %q", pattern)
+				}
+				return &types.ADTSearchResult{Objects: []types.ADTObject{{Name: "ZHELLO_WORLD", Type: "PROG/P"}}}, nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/search", map[string]string{
+			"object_name": "ZHELL*",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		data := decodeSuccess[types.ADTSearchResult](t, rec)
+		if len(data.Objects) != 1 || data.Objects[0].Name != "ZHELLO_WORLD" {
+			t.Errorf("unexpected results: %+v", data.Objects)
+		}
+	})
+
+	t.Run("missing pattern", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/search", map[string]string{})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", rec.Code)
+		}
+	})
+}
+
+// --- objects/list (regression coverage for the package-filter fix) ---
+
+func TestListObjectsHandler(t *testing.T) {
+	t.Run("lists package contents", func(t *testing.T) {
+		fake := &fakeADTClient{
+			getPackageContentsFn: func(ctx context.Context, name string) (*types.ADTPackage, error) {
+				if name != "$TMP" {
+					t.Errorf("expected package $TMP, got %q", name)
+				}
+				return &types.ADTPackage{Name: name, Objects: []types.ADTObject{
+					{Name: "ZHELLO_WORLD", Type: "PROG/P"},
+					{Name: "ZCL_DEMO", Type: "CLAS/OC"},
+				}}, nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/list", map[string]string{
+			"package": "$tmp",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		data := decodeSuccess[[]types.ADTObject](t, rec)
+		if len(data) != 2 {
+			t.Fatalf("expected 2 objects, got %d", len(data))
+		}
+	})
+
+	t.Run("filters package contents by type", func(t *testing.T) {
+		fake := &fakeADTClient{
+			getPackageContentsFn: func(ctx context.Context, name string) (*types.ADTPackage, error) {
+				return &types.ADTPackage{Name: name, Objects: []types.ADTObject{
+					{Name: "ZHELLO_WORLD", Type: "PROG/P"},
+					{Name: "ZHELLO_GO_TEST", Type: "PROG/P"},
+					{Name: "ZCL_DEMO", Type: "CLAS/OC"},
+				}}, nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/list", map[string]string{
+			"package":     "$TMP",
+			"object_type": "PROG",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		data := decodeSuccess[[]types.ADTObject](t, rec)
+		if len(data) != 2 {
+			t.Fatalf("expected 2 PROG objects, got %d: %+v", len(data), data)
+		}
+		for _, obj := range data {
+			if obj.Type != "PROG/P" {
+				t.Errorf("unexpected object leaked through type filter: %+v", obj)
+			}
+		}
+	})
+
+	t.Run("lists packages by pattern", func(t *testing.T) {
+		fake := &fakeADTClient{
+			listPackagesFn: func(ctx context.Context, pattern string) ([]types.ADTPackage, error) {
+				if pattern != "Z*" {
+					t.Errorf("expected pattern Z*, got %q", pattern)
+				}
+				return []types.ADTPackage{{Name: "ZDEMO"}}, nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/list", map[string]string{
+			"object_type": "packages",
+			"object_name": "Z*",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		data := decodeSuccess[[]types.ADTPackage](t, rec)
+		if len(data) != 1 || data[0].Name != "ZDEMO" {
+			t.Errorf("unexpected packages: %+v", data)
+		}
+	})
+
+	t.Run("requires package when not listing package names", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/list", map[string]string{
+			"object_type": "PROG",
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+// --- objects/activate ---
+
+func TestActivateObjectHandler(t *testing.T) {
+	t.Run("activates without source", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/activate", map[string]string{
+			"object_type": "program",
+			"object_name": "zfoo",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		data := decodeSuccess[types.ActivationResult](t, rec)
+		if !data.Success {
+			t.Errorf("expected activation success")
+		}
+	})
+
+	t.Run("saves source before activating", func(t *testing.T) {
+		var saved bool
+		fake := &fakeADTClient{
+			updateProgramFn: func(ctx context.Context, name, source string) error {
+				saved = true
+				return nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/activate", map[string]string{
+			"object_type": "program",
+			"object_name": "zfoo",
+			"source":      "REPORT zfoo.",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if !saved {
+			t.Errorf("expected UpdateProgram to be called before activation")
+		}
+	})
+}
+
+// --- syntax-check, format, completion, navigation ---
+
+func TestSyntaxCheckHandler(t *testing.T) {
+	rs := newTestServer(t, &fakeADTClient{})
+	rec := doJSON(t, rs, http.MethodPost, "/api/v1/syntax-check", map[string]string{
+		"object_type": "program",
+		"object_name": "zfoo",
+		"source":      "REPORT zfoo.",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestFormatSourceHandler(t *testing.T) {
+	rs := newTestServer(t, &fakeADTClient{})
+	rec := doJSON(t, rs, http.MethodPost, "/api/v1/format", map[string]string{
+		"source": "report zfoo.",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	data := decodeSuccess[map[string]string](t, rec)
+	if data["source"] != "report zfoo." {
+		t.Errorf("expected passthrough formatting from fake, got %q", data["source"])
+	}
+}
+
+func TestCompletionHandler(t *testing.T) {
+	rs := newTestServer(t, &fakeADTClient{})
+	rec := doJSON(t, rs, http.MethodPost, "/api/v1/completion", map[string]any{
+		"object_type": "program",
+		"object_name": "zfoo",
+		"source":      "REPORT zfoo.",
+		"line":        1,
+		"column":      1,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestNavigationHandler(t *testing.T) {
+	rs := newTestServer(t, &fakeADTClient{})
+	rec := doJSON(t, rs, http.MethodPost, "/api/v1/navigation", map[string]any{
+		"object_type": "program",
+		"object_name": "zfoo",
+		"source":      "REPORT zfoo.",
+		"line":        1,
+		"column":      1,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// --- unit-tests, transports ---
+
+func TestUnitTestsHandler(t *testing.T) {
+	rs := newTestServer(t, &fakeADTClient{})
+	rec := doJSON(t, rs, http.MethodPost, "/api/v1/unit-tests", map[string]string{
+		"object_type": "class",
+		"object_name": "zcl_demo",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	data := decodeSuccess[types.UnitTestResult](t, rec)
+	if !data.AllPassed {
+		t.Errorf("expected AllPassed from fake default")
+	}
+}
+
+func TestTransportInfoHandler(t *testing.T) {
+	rs := newTestServer(t, &fakeADTClient{})
+	rec := doJSON(t, rs, http.MethodPost, "/api/v1/transports/info", map[string]string{
+		"object_type": "program",
+		"object_name": "zfoo",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateTransportHandler(t *testing.T) {
+	t.Run("creates transport", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/transports/create", map[string]string{
+			"object_type": "program",
+			"object_name": "zfoo",
+			"description": "test transport",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("missing description", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/transports/create", map[string]string{
+			"object_type": "program",
+			"object_name": "zfoo",
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", rec.Code)
+		}
+	})
+}
+
+// --- system/connect, health, version ---
+
+func TestConnectHandler(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{authenticated: true})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/system/connect", nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("connection failure", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{testConnErr: context.DeadlineExceeded})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/system/connect", nil)
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+func TestHealthHandler(t *testing.T) {
+	rs := newTestServer(t, &fakeADTClient{authenticated: true})
+	rec := doJSON(t, rs, http.MethodGet, "/health", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if body["adt_status"] != "connected" {
+		t.Errorf("expected adt_status=connected, got %v", body["adt_status"])
+	}
+}
+
+func TestVersionHandler(t *testing.T) {
+	rs := newTestServer(t, &fakeADTClient{})
+	rec := doJSON(t, rs, http.MethodGet, "/version", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+// --- removed AI endpoints stay gone ---
+
+func TestRemovedAIHandlersReturn410(t *testing.T) {
+	rs := newTestServer(t, &fakeADTClient{})
+	for _, path := range []string{
+		"/api/v1/ai/analyze",
+		"/api/v1/ai/review",
+		"/api/v1/ai/optimize",
+		"/api/v1/ai/create",
+		"/generate-code",
+		"/generate-code-stream",
+	} {
+		rec := doJSON(t, rs, http.MethodPost, path, nil)
+		if rec.Code != http.StatusGone {
+			t.Errorf("%s: expected 410 Gone, got %d", path, rec.Code)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds the repo's first `_test.go` files, focused on the non-AI command surface: `rest/server` (httptest + fake `types.ADTClient`, all non-AI handlers), `internal/client` (httptest-backed, all non-AI methods), `internal/config` (pure-logic `SystemsConfig` + token round-trips), and a regression test for `internal/commands/list.go`'s response-key fix from #86.
- Found and fixed one more bug along the way: `Client.Activate()` was posting to `/api/v1/activate`, a route the server never registers (only `/api/v1/objects/activate` exists) — this silently broke `abaper deploy`'s activation step after a successful create. Fixed to hit the correct route.
- No CI changes needed — the shared `bluefunda/release-foundry` `go-ci.yml` workflow already runs `go test -race ./...` on every PR/push to main, so these tests are picked up automatically.

Closes #89

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all green
- [x] `gofmt -l` clean on all changed/added files

🤖 Generated with [Claude Code](https://claude.com/claude-code)