### PR TITLE
feat(sdk): add public SDK package for embedding the ADT client

### DIFF
--- a/sdk/doc.go
+++ b/sdk/doc.go
@@ -1,0 +1,30 @@
+// Package sdk is the public Go SDK for driving SAP ABAP Development Tools (ADT)
+// operations programmatically — the same client the abaper CLI and REST server
+// use internally, exposed for embedding in your own Go programs.
+//
+// Create a client with New and call any method on the returned types.ADTClient:
+//
+//	client, err := sdk.New(sdk.Options{
+//	    Host:            "https://sap.example.com:44300",
+//	    Client:          "001",
+//	    Username:        "developer",
+//	    Password:        os.Getenv("SAP_PASSWORD"),
+//	    AllowSelfSigned: true,
+//	})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	src, err := client.GetProgram(context.Background(), "ZHELLO_WORLD")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Println(src.Source)
+//
+// New authenticates before returning unless Options.SkipConnect is set. The
+// returned value implements the full types.ADTClient interface (read, write,
+// activate, search, package browse, transports, and language features).
+//
+// This package supersedes the older lib package, which remains for backward
+// compatibility.
+package sdk

--- a/sdk/example_test.go
+++ b/sdk/example_test.go
@@ -1,0 +1,35 @@
+package sdk_test
+
+import (
+	"fmt"
+
+	"github.com/bluefunda/abaper/sdk"
+)
+
+// Example shows the minimal construction of an ADT client. Real use requires a
+// reachable SAP system, so this example uses SkipConnect to avoid a live call.
+func Example() {
+	client, err := sdk.New(sdk.Options{
+		Host:            "https://sap.example.com:44300",
+		Client:          "001",
+		Username:        "developer",
+		Password:        "secret",
+		AllowSelfSigned: true,
+		SkipConnect:     true, // omit in real use to authenticate on New
+	})
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	_ = client
+	fmt.Println("client created")
+	// Output: client created
+}
+
+// Example_missingCredentials shows the validation error when a required field
+// is omitted.
+func Example_missingCredentials() {
+	_, err := sdk.New(sdk.Options{Host: "https://sap.example.com:44300"})
+	fmt.Println(err)
+	// Output: sdk: Username is required
+}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -1,0 +1,101 @@
+package sdk
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bluefunda/abaper/internal/adt"
+	"github.com/bluefunda/abaper/types"
+)
+
+// Defaults applied by New when the corresponding Option is left zero.
+const (
+	defaultClient         = "100"
+	defaultLanguage       = "EN"
+	defaultConnectTimeout = 30 * time.Second
+	defaultRequestTimeout = 120 * time.Second
+)
+
+// Options configures a SAP ADT client. Host, Username, and Password are
+// required; the rest have sensible defaults.
+type Options struct {
+	// Host is the SAP ADT base URL, e.g. "https://sap.example.com:44300". Required.
+	Host string
+	// Client is the SAP client (mandant) number. Defaults to "100".
+	Client string
+	// Username is the SAP user. Required.
+	Username string
+	// Password is the SAP password. Required.
+	Password string
+	// Language is the logon language. Defaults to "EN".
+	Language string
+	// AllowSelfSigned skips TLS certificate verification. Useful for trial
+	// systems with self-signed certs; do not enable against production.
+	AllowSelfSigned bool
+	// ConnectTimeout bounds the initial connection. Defaults to 30s.
+	ConnectTimeout time.Duration
+	// RequestTimeout bounds each ADT request. Defaults to 120s.
+	RequestTimeout time.Duration
+	// Debug enables verbose logging in the underlying client.
+	Debug bool
+	// SkipConnect returns the client without calling Authenticate. The caller
+	// is then responsible for authenticating before issuing requests.
+	SkipConnect bool
+}
+
+// New builds a SAP ADT client from Options and, unless SkipConnect is set,
+// authenticates before returning. The returned value implements the full
+// types.ADTClient interface.
+func New(opts Options) (types.ADTClient, error) {
+	if opts.Host == "" {
+		return nil, fmt.Errorf("sdk: Host is required")
+	}
+	if opts.Username == "" {
+		return nil, fmt.Errorf("sdk: Username is required")
+	}
+	if opts.Password == "" {
+		return nil, fmt.Errorf("sdk: Password is required")
+	}
+
+	cfg := &types.ADTConfig{
+		Host:            opts.Host,
+		Client:          orDefault(opts.Client, defaultClient),
+		Username:        opts.Username,
+		Password:        opts.Password,
+		Language:        orDefault(opts.Language, defaultLanguage),
+		AllowSelfSigned: opts.AllowSelfSigned,
+		ConnectTimeout:  opts.ConnectTimeout,
+		RequestTimeout:  opts.RequestTimeout,
+		Debug:           opts.Debug,
+	}
+	if cfg.ConnectTimeout == 0 {
+		cfg.ConnectTimeout = defaultConnectTimeout
+	}
+	if cfg.RequestTimeout == 0 {
+		cfg.RequestTimeout = defaultRequestTimeout
+	}
+
+	client := adt.NewADTClient(cfg)
+
+	if !opts.SkipConnect {
+		if err := client.Authenticate(); err != nil {
+			return nil, fmt.Errorf("sdk: authentication failed: %w", err)
+		}
+	}
+
+	return client, nil
+}
+
+// NewFromConfig builds a client from a fully-specified ADTConfig without
+// authenticating. Use this for advanced scenarios that need direct control
+// over the configuration; most callers should prefer New.
+func NewFromConfig(cfg *types.ADTConfig) types.ADTClient {
+	return adt.NewADTClient(cfg)
+}
+
+func orDefault(v, def string) string {
+	if v == "" {
+		return def
+	}
+	return v
+}

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -1,0 +1,101 @@
+package sdk
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bluefunda/abaper/types"
+)
+
+func TestNew_RequiredFields(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"missing host", Options{Username: "dev", Password: "pw", SkipConnect: true}},
+		{"missing username", Options{Host: "https://h", Password: "pw", SkipConnect: true}},
+		{"missing password", Options{Host: "https://h", Username: "dev", SkipConnect: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, err := New(tc.opts)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+			if client != nil {
+				t.Errorf("expected nil client on error, got %v", client)
+			}
+		})
+	}
+}
+
+func TestNew_SkipConnectReturnsClient(t *testing.T) {
+	client, err := New(Options{
+		Host:            "https://sap.example.com:44300",
+		Username:        "developer",
+		Password:        "secret",
+		AllowSelfSigned: true,
+		SkipConnect:     true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected a non-nil client")
+	}
+	// The concrete client must satisfy the full public interface.
+	var _ types.ADTClient = client
+	if client.IsAuthenticated() {
+		t.Error("expected client to be unauthenticated when SkipConnect is set")
+	}
+}
+
+func TestNewFromConfig(t *testing.T) {
+	client := NewFromConfig(&types.ADTConfig{
+		Host:     "https://sap.example.com:44300",
+		Client:   "001",
+		Username: "developer",
+		Password: "secret",
+	})
+	if client == nil {
+		t.Fatal("expected a non-nil client")
+	}
+	var _ types.ADTClient = client
+}
+
+func TestOrDefault(t *testing.T) {
+	if got := orDefault("", "fallback"); got != "fallback" {
+		t.Errorf("expected fallback, got %q", got)
+	}
+	if got := orDefault("value", "fallback"); got != "value" {
+		t.Errorf("expected value, got %q", got)
+	}
+}
+
+func TestNew_DefaultsDoNotError(t *testing.T) {
+	// Exercises the default-application path (client/language/timeouts) without
+	// a live connection.
+	_, err := New(Options{
+		Host:           "https://sap.example.com:44300",
+		Username:       "developer",
+		Password:       "secret",
+		ConnectTimeout: 0,
+		RequestTimeout: 0,
+		SkipConnect:    true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error applying defaults: %v", err)
+	}
+	// Sanity: non-zero durations are valid inputs too.
+	_, err = New(Options{
+		Host:           "https://sap.example.com:44300",
+		Username:       "developer",
+		Password:       "secret",
+		ConnectTimeout: 5 * time.Second,
+		RequestTimeout: 10 * time.Second,
+		SkipConnect:    true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error with explicit timeouts: %v", err)
+	}
+}

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -43,8 +43,7 @@ func TestNew_SkipConnectReturnsClient(t *testing.T) {
 	if client == nil {
 		t.Fatal("expected a non-nil client")
 	}
-	// The concrete client must satisfy the full public interface.
-	var _ types.ADTClient = client
+	// New returns the public types.ADTClient interface directly.
 	if client.IsAuthenticated() {
 		t.Error("expected client to be unauthenticated when SkipConnect is set")
 	}
@@ -60,7 +59,6 @@ func TestNewFromConfig(t *testing.T) {
 	if client == nil {
 		t.Fatal("expected a non-nil client")
 	}
-	var _ types.ADTClient = client
 }
 
 func TestOrDefault(t *testing.T) {


### PR DESCRIPTION
## Summary

Gives abaper a discoverable, documented public SDK — mirroring bai's `sdk/agent` — so external Go programs can drive SAP ADT operations without going through the CLI. Previously this was only possible via the undocumented `lib/` wrapper.

- `sdk.New(Options) (types.ADTClient, error)` — validates required fields, applies defaults (client `100`, language `EN`, 30s/120s timeouts), builds the client via `internal/adt`, and authenticates unless `Options.SkipConnect` is set.
- `sdk.NewFromConfig(*types.ADTConfig) types.ADTClient` — advanced escape hatch, no auth.
- Returns the existing public `types.ADTClient` interface (~44 methods: read, write, activate, search, package browse, transports, language features). Concrete impl stays hidden in `internal/adt`.
- `doc.go` package overview + runnable godoc `example_test.go` + unit tests.
- Supersedes `lib/` (kept for backward compatibility).

Usage:
```go
client, err := sdk.New(sdk.Options{
    Host: "https://sap.example.com:44300", Client: "001",
    Username: "developer", Password: os.Getenv("SAP_PASSWORD"),
    AllowSelfSigned: true,
})
src, _ := client.GetProgram(ctx, "ZHELLO_WORLD")
```

Closes #95

## Test plan

- [x] `go build ./...`, `go vet ./sdk/...`, `gofmt -l sdk/` clean
- [x] `go test ./sdk/...` — validation, defaults, SkipConnect, examples all pass
- [x] `go doc ./sdk` renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)