### PR TITLE
fix(adt): repair packages/contents parsing and enable DDIC creation

### DIFF
--- a/internal/adt/client.go
+++ b/internal/adt/client.go
@@ -594,7 +594,9 @@ func (c *ADTClientImpl) GetNodeContents(ctx context.Context, packageName string)
 	}
 
 	c.addAuthHeaders(req)
-	req.Header.Set("Accept", "application/xml")
+	// SAP ADT's nodestructure endpoint only negotiates application/vnd.sap.as+xml;
+	// a plain application/xml Accept header is rejected with HTTP 406.
+	req.Header.Set("Accept", "application/vnd.sap.as+xml")
 
 	resp, err := c.doRequest(req)
 	if err != nil {
@@ -615,8 +617,29 @@ func (c *ADTClientImpl) GetNodeContents(ctx context.Context, packageName string)
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	// ADT nodestructure XML: two distinct response formats are observed in the wild.
-	// We parse a flexible envelope that covers both attribute-style and element-style variants.
+	result, err := parseNodeStructureXML(responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	c.logger.Info("Node contents retrieved",
+		zap.String("package", packageName),
+		zap.Int("nodes", len(result.Nodes)),
+		zap.Int("object_types", len(result.ObjectTypes)))
+
+	return result, nil
+}
+
+// parseNodeStructureXML parses a SAP ADT nodestructure response.
+//
+// The endpoint responds with application/vnd.sap.as+xml, an ABAP serialization
+// wrapped in <asx:abap><asx:values><DATA>. Repository objects live under
+// TREE_CONTENT/SEU_ADT_REPOSITORY_OBJ_NODE and the type descriptors under
+// OBJECT_TYPES/SEU_ADT_OBJECT_TYPE_INFO. Element local names are matched
+// (namespace prefixes like asx: are ignored by encoding/xml). Virtual folder /
+// category placeholder rows (empty OBJECT_NAME) are skipped — callers want
+// addressable repository objects.
+func parseNodeStructureXML(body []byte) (*types.PackageContentsResult, error) {
 	type xmlObjectType struct {
 		Type  string `xml:"OBJECT_TYPE"`
 		Label string `xml:"OBJECT_TYPE_LABEL"`
@@ -629,18 +652,21 @@ func (c *ADTClientImpl) GetNodeContents(ctx context.Context, packageName string)
 		Expandable  string `xml:"EXPANDABLE"` // "X" or "" in ABAP-style XML
 	}
 	type xmlEnvelope struct {
-		XMLName     xml.Name        `xml:"nodeStructure"`
-		ObjectTypes []xmlObjectType `xml:"objectTypeDescriptions>objectTypeDescription"`
-		Nodes       []xmlNode       `xml:"objectNodes>SEU_ADT_REPOSITORY_OBJ_NODE"`
+		XMLName     xml.Name        `xml:"abap"`
+		Nodes       []xmlNode       `xml:"values>DATA>TREE_CONTENT>SEU_ADT_REPOSITORY_OBJ_NODE"`
+		ObjectTypes []xmlObjectType `xml:"values>DATA>OBJECT_TYPES>SEU_ADT_OBJECT_TYPE_INFO"`
 	}
 
 	var envelope xmlEnvelope
-	if err := xml.Unmarshal(responseBody, &envelope); err != nil {
+	if err := xml.Unmarshal(body, &envelope); err != nil {
 		return nil, fmt.Errorf("parse nodestructure response: %w", err)
 	}
 
 	nodes := make([]types.PackageNode, 0, len(envelope.Nodes))
 	for _, n := range envelope.Nodes {
+		if n.Name == "" {
+			continue
+		}
 		nodes = append(nodes, types.PackageNode{
 			Name:        n.Name,
 			Type:        n.Type,
@@ -657,11 +683,6 @@ func (c *ADTClientImpl) GetNodeContents(ctx context.Context, packageName string)
 			Label: ot.Label,
 		})
 	}
-
-	c.logger.Info("Node contents retrieved",
-		zap.String("package", packageName),
-		zap.Int("nodes", len(nodes)),
-		zap.Int("object_types", len(objectTypes)))
 
 	return &types.PackageContentsResult{
 		Nodes:       nodes,
@@ -1079,6 +1100,10 @@ func (c *ADTClientImpl) createObjectMetadata(ctx context.Context, endpoint, xmlP
 	}
 	c.addAuthHeaders(req)
 	req.Header.Set("Content-Type", "application/*")
+	// Override the default atomsvc Accept from addAuthHeaders: DDIC "blue"
+	// creation endpoints reject application/atomsvc+xml with HTTP 406, while
+	// the permissive application/* is accepted across all creatable types.
+	req.Header.Set("Accept", "application/*")
 	resp, err := c.doRequest(req)
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
@@ -1250,18 +1275,59 @@ func (c *ADTClientImpl) CreateInclude(ctx context.Context, name, description, so
 		"INCL", name, source, source != "")
 }
 
-// CreateStructure creates a new ABAP structure (DDIC).
-// SAP ADT does not expose a direct HTTP creation endpoint for DDIC structures;
-// they must be created through the DDIC workbench. This returns a clear error.
-func (c *ADTClientImpl) CreateStructure(ctx context.Context, name, description, source string) error {
-	return fmt.Errorf("CreateStructure: SAP ADT does not support programmatic DDIC structure creation via REST — use transaction SE11")
+// ddicBlueCreatePayload is the create-shell body for source-based DDIC objects
+// (tables and structures), which SAP models as "blue" workbench sources. It
+// mirrors abap-adt-api's createBodySimple for these types.
+type ddicBlueCreatePayload struct {
+	XMLName     xml.Name        `xml:"blue:blueSource"`
+	BlueNS      string          `xml:"xmlns:blue,attr"`
+	AdtcoreNS   string          `xml:"xmlns:adtcore,attr"`
+	Description string          `xml:"adtcore:description,attr"`
+	Name        string          `xml:"adtcore:name,attr"`
+	Type        string          `xml:"adtcore:type,attr"`
+	Responsible string          `xml:"adtcore:responsible,attr"`
+	PackageRef  classPackageRef `xml:"adtcore:packageRef"`
 }
 
-// CreateTable creates a new ABAP table (DDIC).
-// SAP ADT does not expose a direct HTTP creation endpoint for DDIC tables;
-// they must be created through the DDIC workbench. This returns a clear error.
+// createDDICBlueSource creates a source-based DDIC object (structure or table)
+// using the same create-shell → write-source → activate flow abaper-ts relies on
+// (via abap-adt-api). SAP ADT *does* expose these endpoints — the object is
+// created at createEndpoint, then its DDL-style source is written to
+// objectBasePath+name+"/source/main". Activation runs only when source is given
+// (an empty DDIC shell cannot activate). Objects are created in $TMP.
+func (c *ADTClientImpl) createDDICBlueSource(ctx context.Context, typeID, createEndpoint, objectBasePath, name, description, source string) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	payload := ddicBlueCreatePayload{
+		BlueNS:      "http://www.sap.com/wbobj/blue",
+		AdtcoreNS:   "http://www.sap.com/adt/core",
+		Description: description,
+		Name:        name,
+		Type:        typeID,
+		Responsible: strings.ToUpper(strings.TrimSpace(c.config.Username)),
+		PackageRef:  classPackageRef{Name: "$TMP"},
+	}
+	xmlBytes, err := xml.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", typeID, err)
+	}
+	if err := c.createObjectMetadata(ctx, createEndpoint, xml.Header+string(xmlBytes)); err != nil {
+		return fmt.Errorf("create %s %s: %w", typeID, name, err)
+	}
+	nameLower := strings.ToLower(name)
+	return c.createAndPopulate(ctx, createEndpoint,
+		objectBasePath+nameLower,
+		objectBasePath+nameLower+"/source/main",
+		typeID, name, source, source != "")
+}
+
+// CreateStructure creates a new ABAP DDIC structure (TABL/DS) via ADT.
+func (c *ADTClientImpl) CreateStructure(ctx context.Context, name, description, source string) error {
+	return c.createDDICBlueSource(ctx, "TABL/DS", "/ddic/structures", "/ddic/structures/", name, description, source)
+}
+
+// CreateTable creates a new ABAP DDIC table (TABL/DT) via ADT.
 func (c *ADTClientImpl) CreateTable(ctx context.Context, name, description, source string) error {
-	return fmt.Errorf("CreateTable: SAP ADT does not support programmatic DDIC table creation via REST — use transaction SE11")
+	return c.createDDICBlueSource(ctx, "TABL/DT", "/ddic/tables", "/ddic/tables/", name, description, source)
 }
 
 // addAuthHeaders adds authentication and session headers to the request
@@ -1749,7 +1815,10 @@ func (c *ADTClientImpl) lockObject(ctx context.Context, objectPath string) (lock
 	}
 
 	c.addAuthHeaders(req)
-	req.Header.Set("Accept", "application/*")
+	// DDIC objects reject a bare application/* Accept on LOCK with HTTP 406; the
+	// ADT lock endpoint requires the lock.result media type. This header works
+	// for source-library objects too.
+	req.Header.Set("Accept", "application/*,application/vnd.sap.as+xml;charset=UTF-8;dataname=com.sap.adt.lock.result")
 	req.Header.Set("Content-Length", "0")
 
 	c.logger.Debug("Locking object", zap.String("object_path", objectPath), zap.String("url", url))

--- a/internal/adt/nodestructure_test.go
+++ b/internal/adt/nodestructure_test.go
@@ -1,0 +1,65 @@
+package adt
+
+import "testing"
+
+// sampleNodeStructureXML mirrors the application/vnd.sap.as+xml shape SAP ADT
+// returns from /repository/nodestructure: an <asx:abap> envelope with repository
+// objects under TREE_CONTENT and type descriptors under OBJECT_TYPES. It includes
+// a virtual folder row (empty OBJECT_NAME) that must be filtered out.
+const sampleNodeStructureXML = `<?xml version="1.0" encoding="utf-8"?>
+<asx:abap version="1.0" xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA>
+<TREE_CONTENT>
+<SEU_ADT_REPOSITORY_OBJ_NODE><OBJECT_TYPE>DEVC/Q4H</OBJECT_TYPE><OBJECT_NAME/><TECH_NAME>$TMP</TECH_NAME><OBJECT_URI/><EXPANDABLE>X</EXPANDABLE><DESCRIPTION/></SEU_ADT_REPOSITORY_OBJ_NODE>
+<SEU_ADT_REPOSITORY_OBJ_NODE><OBJECT_TYPE>PROG/P</OBJECT_TYPE><OBJECT_NAME>ZHELLO_WORLD</OBJECT_NAME><TECH_NAME>ZHELLO_WORLD</TECH_NAME><OBJECT_URI>/sap/bc/adt/programs/programs/zhello_world</OBJECT_URI><EXPANDABLE/><DESCRIPTION>Hello World</DESCRIPTION></SEU_ADT_REPOSITORY_OBJ_NODE>
+<SEU_ADT_REPOSITORY_OBJ_NODE><OBJECT_TYPE>TABL/DT</OBJECT_TYPE><OBJECT_NAME>ZABAPGIT</OBJECT_NAME><TECH_NAME>ZABAPGIT</TECH_NAME><OBJECT_URI>/sap/bc/adt/ddic/tables/zabapgit</OBJECT_URI><EXPANDABLE>X</EXPANDABLE><DESCRIPTION>abapGit table</DESCRIPTION></SEU_ADT_REPOSITORY_OBJ_NODE>
+</TREE_CONTENT>
+<CATEGORIES></CATEGORIES>
+<OBJECT_TYPES>
+<SEU_ADT_OBJECT_TYPE_INFO><OBJECT_TYPE>PROG/P</OBJECT_TYPE><CATEGORY_TAG>source_library</CATEGORY_TAG><OBJECT_TYPE_LABEL>Program</OBJECT_TYPE_LABEL></SEU_ADT_OBJECT_TYPE_INFO>
+<SEU_ADT_OBJECT_TYPE_INFO><OBJECT_TYPE>TABL/DT</OBJECT_TYPE><CATEGORY_TAG>dictionary</CATEGORY_TAG><OBJECT_TYPE_LABEL>Database Table</OBJECT_TYPE_LABEL></SEU_ADT_OBJECT_TYPE_INFO>
+</OBJECT_TYPES>
+</DATA></asx:values></asx:abap>`
+
+func TestParseNodeStructureXML(t *testing.T) {
+	result, err := parseNodeStructureXML([]byte(sampleNodeStructureXML))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Virtual folder row (empty OBJECT_NAME) must be filtered; two real objects remain.
+	if len(result.Nodes) != 2 {
+		t.Fatalf("expected 2 object nodes, got %d: %+v", len(result.Nodes), result.Nodes)
+	}
+
+	prog := result.Nodes[0]
+	if prog.Name != "ZHELLO_WORLD" || prog.Type != "PROG/P" {
+		t.Errorf("unexpected first node: %+v", prog)
+	}
+	if prog.URI != "/sap/bc/adt/programs/programs/zhello_world" {
+		t.Errorf("expected program URI, got %q", prog.URI)
+	}
+	if prog.Description != "Hello World" {
+		t.Errorf("expected description, got %q", prog.Description)
+	}
+	if prog.Expandable {
+		t.Errorf("program should not be expandable")
+	}
+
+	tbl := result.Nodes[1]
+	if tbl.Name != "ZABAPGIT" || !tbl.Expandable {
+		t.Errorf("expected expandable table node, got %+v", tbl)
+	}
+
+	if len(result.ObjectTypes) != 2 {
+		t.Fatalf("expected 2 object types, got %d", len(result.ObjectTypes))
+	}
+	if result.ObjectTypes[0].Type != "PROG/P" || result.ObjectTypes[0].Label != "Program" {
+		t.Errorf("unexpected object type: %+v", result.ObjectTypes[0])
+	}
+}
+
+func TestParseNodeStructureXML_Invalid(t *testing.T) {
+	if _, err := parseNodeStructureXML([]byte("not xml")); err == nil {
+		t.Fatal("expected error for invalid XML")
+	}
+}


### PR DESCRIPTION
## Summary

Found by parity-testing the ADT operations against a **live SAP system**, using `abap-adt-api` (the library abaper-ts depends on) as the reference. Two operations that abaper-ts supports were broken/missing in the Go server:

### 1. `packages/contents` (expand package) — was fully broken
- The `nodestructure` request sent `Accept: application/xml` → SAP returns **HTTP 406**; the endpoint only negotiates `application/vnd.sap.as+xml`.
- The response parser expected a `<nodeStructure>` root, but SAP returns an `<asx:abap><asx:values><DATA>` envelope (objects under `TREE_CONTENT/SEU_ADT_REPOSITORY_OBJ_NODE`, descriptors under `OBJECT_TYPES/SEU_ADT_OBJECT_TYPE_INFO`). Rewrote the parser to match, extracted it into a unit-tested helper (`parseNodeStructureXML`), and filtered virtual-folder placeholder rows (empty `OBJECT_NAME`).

### 2. DDIC creation — was falsely refused ("use SE11")
- `CreateStructure`/`CreateTable` now create via ADT (`ddic/structures`, `ddic/tables`) using the `blue:blueSource` create-shell → write-source → activate flow, mirroring `abap-adt-api`.
- `createObjectMetadata` now sends `Accept: application/*` (DDIC create endpoints reject the default `atomsvc` Accept with 406).
- `lockObject` now sends the `com.sap.adt.lock.result` media type (DDIC objects reject a bare `application/*` lock Accept with 406; source-library objects tolerate both).

## Verification (live SAP)

| Operation | Result |
|---|---|
| Search programs / classes | ✅ |
| **Expand package `$TMP`** | ✅ 378 objects w/ URIs, 26 object types (was HTTP 406) |
| Create program / class | ✅ |
| Save-mode `objects/create` + bare `/api/v1/activate` | ✅ |
| **Create DDIC structure** | ✅ create + activate with valid DDL (was refused) |

## Tests

- New `parseNodeStructureXML` unit test (real `asx:abap` sample, folder-row filtering).
- `go build`, `go vet`, `go test ./...` all pass.

## Notes / follow-ups
- DDIC create requires valid DDL source (e.g. the `@AbapCatalog.enhancement.category` annotation) — invalid source is rejected by SAP's syntax check, same as abaper-ts.
- Not in this PR (lower priority, no current client usage): `CreateDataElement`/`CreateDomain`/`CreateDDLSource`, `DeleteObject`, pre-create validation, and passing a non-`$TMP` package/transport into DDIC creation. Reference details captured for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)