### PR TITLE
feat(adt): full CRUD parity for function modules, DDIC objects, CDS views

### DIFF
--- a/docs/OBJECT_TYPE_PARITY_PLAN.md
+++ b/docs/OBJECT_TYPE_PARITY_PLAN.md
@@ -1,0 +1,133 @@
+# abaper — Object Type Parity Plan (vs. abap-adt-api)
+
+**Status: All 6 plan items implemented and verified live against
+abap.bluefunda.com, plus one additional bug found during live testing
+(`FUNCTIONGROUP` alias missing from `objectTypeToURI`, breaking
+activation/syntax-check for that alias). Unit tests added for all fixes.**
+
+Reference: `marcellourbani/abap-adt-api` (TypeScript), cloned to `~/src/abap-adt-api`.
+Scope (per user direction): Program, Class, Function Module, Function Group,
+DDIC objects (Table, Structure, Domain, Data Element), CDS Views (DDLS/DF).
+Read → Edit → Create, in that order, TDD: write/run a test against the live
+system first, fix code until it passes.
+
+Live system used for verification: `abap.bluefunda.com`, client `001`, user
+`developer`, via a locally-run `abaper serve --port 8092` (own instance,
+separate from another concurrent session using port 8080 — different Z-object
+naming prefix `ZABPB_` used to avoid collisions).
+
+## Findings: Read (confirmed live, 2026-07-02)
+
+| Type | Search | REST get | Notes |
+|---|---|---|---|
+| Program (PROG/P) | ✅ | ✅ | |
+| Class (CLAS/OC) | ✅ | ✅ | |
+| Function Group (FUGR/F) | ✅ | ✅ | |
+| Function Module (FUGR/FF) | ✅ | ✅ | needs `args[0]=<group>` |
+| Table (TABL/DT) | ✅ | ✅ | |
+| Structure (TABL/DS) | ✅ | ✅ | |
+| CDS View (DDLS/DF) | ✅ | ✅ | |
+| Domain (DOMA/DD) | ✅ | ❌ | `getObjectHandler` has no DOMAIN case; `GetTypeInfo` internally tries `/ddic/domains/{n}/source/main` which 404s live — domains have no source/main representation |
+| Data Element (DTEL/DE) | ✅ | ❌ | same issue; `/ddic/dataelements/{n}` needs plain GET (no Accept override), not the `getTypeSource` path used today |
+
+## Findings: Create/Edit bugs
+
+1. **`CreateFunctionGroup` bug** (`internal/adt/client.go:1206-1238`): sets
+   `Type: "FUGR/FF"` (function **module** type ID) instead of `"FUGR/F"`
+   (function **group**), and XML root element is `fgroup:functionGroup`
+   instead of reference's `group:abapFunctionGroup`. Confirmed live: SAP
+   rejects with `ExceptionInvalidData — Data is invalid and could not be
+   converted`.
+2. **No function module create** (`CreateFunction` missing from
+   `types.SourceWriter` + `internal/adt/client.go`). `UpdateFunction` exists
+   but nothing creates a new FM inside a group. REST `createObjectHandler`
+   has no `FUNCTION` case (400 unsupported).
+3. **No table/structure update** (`UpdateTable`/`UpdateStructure` missing).
+   Can create but never edit again via source.
+4. **No CDS view (DDLS) create/update**. `GetDDLSource` (read) exists;
+   `CreateDDLS`/`UpdateDDLS` do not. Reference: creationPath
+   `ddic/ddl/sources`, root `ddl:ddlSource`, namespace
+   `http://www.sap.com/adt/ddic/ddlsources`, typeId `DDLS/DF`. Activation and
+   syntax-check already work generically for DDLS (`objectTypeToURI` has a
+   case) — only create/update are missing.
+5. **No domain/data-element create/update**. These are **not** source-text
+   objects like the others — reference confirms a distinct structured-XML
+   properties API (`getDomainProperties`/`setDomainProperties`,
+   `getDataElementProperties`/`setDataElementProperties`, see
+   `abap-adt-api/src/api/objectcontents.ts`). Plain GET on
+   `/ddic/domains/{name}` (no special Accept header) returns the full
+   metadata+content XML directly; PUT with `?lockHandle=` sets it. This is a
+   different shape from the `source string` convention used everywhere else
+   in `SourceWriter` — needs its own typed options struct.
+
+## Plan (priority order)
+
+1. Wire domain/data-element **read** into REST (`getObjectHandler`), fix
+   `GetTypeInfo` to use plain GET instead of the wrong source/main + Accept
+   dance. *(quick)*
+2. Fix `CreateFunctionGroup` type ID + root element bug. *(quick)*
+3. Add `CreateFunction` (function module create within a group) —
+   mirror `createAndPopulate` pattern used by programs/classes, endpoint
+   `functions/groups/{group}/fmodules`. *(medium)*
+4. Add `UpdateTable` / `UpdateStructure` — same lock → setObjectSource →
+   unlock flow already used by `UpdateProgram` et al, pointed at
+   `/ddic/tables/{n}/source/main` / `/ddic/structures/{n}/source/main`.
+   *(quick — endpoints and lock/unlock already exist)*
+5. Add `CreateDDLS` / `UpdateDDLS` for CDS views — mirror `CreateInclude`
+   pattern (metadata create shell + populate). *(medium)*
+6. Add domain/data-element **create/update** via the structured-properties
+   API. New types (`DomainProperties`, `DataElementProperties` — trimmed to
+   the fields abaper needs) + `CreateDomain`/`UpdateDomain`/
+   `CreateDataElement`/`UpdateDataElement`. *(large — new XML shape, not the
+   source-text convention)*
+
+Each item: write a REST-handler unit test with `fakeADTClient` first (red),
+implement, confirm green, then verify live via curl against the `:8092`
+instance, then a live-backed integration test where practical.
+
+## Test strategy
+
+- Unit tests (`rest/server/server_test.go`, `fake_adt_client_test.go`):
+  extend for every new/changed handler case, run in CI via existing
+  `go-ci.yml` (no live system needed).
+- Live verification: manual curl against `abaper serve` on `:8092` during
+  development, using disposable `ZABPB_*`-prefixed objects in `$TMP` to avoid
+  touching real content or colliding with the other concurrent session's
+  `ZABAPER_*`-prefixed objects.
+
+## Results (2026-07-02)
+
+Items 1–5 implemented, unit-tested, and verified live end-to-end
+(create → read → update → activate) against `abap.bluefunda.com`:
+
+- Domain/data-element **read** now reachable via REST (`GET domain/data_element`).
+- `CreateFunctionGroup` bug fixed (was silently broken — SAP rejected every
+  call with `ExceptionInvalidData`).
+- `CreateFunction` (function module create) added and verified inside a
+  freshly-created group.
+- `UpdateTable` / `UpdateStructure` added; both verified with a real
+  create → activate → update → re-activate cycle.
+- `CreateDDLS` / `UpdateDDLS` (CDS views) added and verified the same way.
+
+**Bonus fix found via live testing (not in the original plan):**
+`objectTypeToURI` (used by `ActivateObject`/`SyntaxCheck`) recognized `FUGR`
+and `FUNCTION_GROUP` but not `FUNCTIONGROUP` — the alias every other REST
+handler in this codebase accepts. Activating a function group created via the
+REST API failed with "unsupported object type for activation" until fixed.
+Added `FUNCTIONGROUP` to the switch; covered by `TestObjectTypeToURI`.
+
+**Known gap, not fixed (documented, low priority):** individual function
+module activation. `ActivateObject(ctx, objectType, objectName)` takes no
+function-group parameter, so a function module can't be activated on its own
+through this API — only its containing function group can. Every other
+create/read/update path for function modules works. Fixing this would require
+either changing the `ObjectActivator` interface signature (breaking change)
+or adding a separate function-module-specific activation method.
+
+**Deferred (item 6): Domain/Data Element create/update.** Confirmed live that
+these need the structured-properties XML API described above, not the
+source-text convention every other `SourceWriter` method uses. This is a
+genuinely different, larger feature (new request/response types, no reuse of
+`lockObject`/`setObjectSource`/`createAndPopulate`). Recommend a separate
+follow-up issue/PR scoped specifically to this, rather than folding it into
+this change.

--- a/internal/adt/client.go
+++ b/internal/adt/client.go
@@ -30,7 +30,7 @@ const (
 	structuresEndpoint      = "/ddic/structures/%s/source/main"
 	includesEndpoint        = "/programs/includes/%s/source/main"
 	interfacesEndpoint      = "/oo/interfaces/%s/source/main"
-	domainsEndpoint         = "/ddic/domains/%s/source/main"
+	domainsEndpoint         = "/ddic/domains/%s"
 	dataElementsEndpoint    = "/ddic/dataelements/%s"
 	ddlSourcesEndpoint      = "/ddic/ddl/sources/%s/source/main"
 	searchEndpoint = "/repository/informationsystem/search"
@@ -720,7 +720,7 @@ func (c *ADTClientImpl) GetTypeInfo(ctx context.Context, typeName string) (*type
 
 	// First try as domain
 	domainURL := fmt.Sprintf("%s"+domainsEndpoint, c.baseURL, typeName)
-	if source, err := c.getTypeSource(ctx, domainURL, "text/plain"); err == nil {
+	if source, err := c.getTypeSource(ctx, domainURL, "application/*"); err == nil {
 		return &types.ADTTypeInfo{
 			TypeName:   typeName,
 			TypeKind:   "DOMAIN",
@@ -731,7 +731,7 @@ func (c *ADTClientImpl) GetTypeInfo(ctx context.Context, typeName string) (*type
 
 	// If domain fails, try as data element
 	dataElementURL := fmt.Sprintf("%s"+dataElementsEndpoint, c.baseURL, typeName)
-	if source, err := c.getTypeSource(ctx, dataElementURL, "application/xml"); err == nil {
+	if source, err := c.getTypeSource(ctx, dataElementURL, "application/*"); err == nil {
 		return &types.ADTTypeInfo{
 			TypeName:   typeName,
 			TypeKind:   "DATA_ELEMENT",
@@ -1204,8 +1204,8 @@ func (c *ADTClientImpl) CreateInterface(ctx context.Context, name, description, 
 }
 
 type functionGroupCreatePayload struct {
-	XMLName     xml.Name        `xml:"fgroup:functionGroup"`
-	FgroupNS    string          `xml:"xmlns:fgroup,attr"`
+	XMLName     xml.Name        `xml:"group:abapFunctionGroup"`
+	FgroupNS    string          `xml:"xmlns:group,attr"`
 	AdtcoreNS   string          `xml:"xmlns:adtcore,attr"`
 	Description string          `xml:"adtcore:description,attr"`
 	Name        string          `xml:"adtcore:name,attr"`
@@ -1221,7 +1221,7 @@ func (c *ADTClientImpl) CreateFunctionGroup(ctx context.Context, name, descripti
 		AdtcoreNS:   "http://www.sap.com/adt/core",
 		Description: description,
 		Name:        name,
-		Type:        "FUGR/FF",
+		Type:        "FUGR/F",
 		Responsible: strings.ToUpper(strings.TrimSpace(c.config.Username)),
 		PackageRef:  classPackageRef{Name: "$TMP"},
 	}
@@ -1237,6 +1237,55 @@ func (c *ADTClientImpl) CreateFunctionGroup(ctx context.Context, name, descripti
 		"/functions/groups/"+nameLower,
 		"/functions/groups/"+nameLower+"/source/main",
 		"FUGR", name, source, source != "")
+}
+
+type functionContainerRef struct {
+	Name string `xml:"adtcore:name,attr"`
+	Type string `xml:"adtcore:type,attr"`
+	URI  string `xml:"adtcore:uri,attr"`
+}
+
+type functionModuleCreatePayload struct {
+	XMLName      xml.Name             `xml:"fmodule:abapFunctionModule"`
+	FmoduleNS    string               `xml:"xmlns:fmodule,attr"`
+	AdtcoreNS    string               `xml:"xmlns:adtcore,attr"`
+	Description  string               `xml:"adtcore:description,attr"`
+	Name         string               `xml:"adtcore:name,attr"`
+	Type         string               `xml:"adtcore:type,attr"`
+	ContainerRef functionContainerRef `xml:"adtcore:containerRef"`
+}
+
+// CreateFunction creates a new function module (FUGR/FF) within an existing function group.
+func (c *ADTClientImpl) CreateFunction(ctx context.Context, name, functionGroup, description, source string) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	functionGroup = strings.ToUpper(strings.TrimSpace(functionGroup))
+	if functionGroup == "" {
+		return fmt.Errorf("function group is required to create a function module")
+	}
+	groupLower := strings.ToLower(functionGroup)
+	payload := functionModuleCreatePayload{
+		FmoduleNS:   "http://www.sap.com/adt/functions/fmodules",
+		AdtcoreNS:   "http://www.sap.com/adt/core",
+		Description: description,
+		Name:        name,
+		Type:        "FUGR/FF",
+		ContainerRef: functionContainerRef{
+			Name: functionGroup,
+			Type: "FUGR/F",
+			URI:  "/sap/bc/adt/functions/groups/" + groupLower,
+		},
+	}
+	xmlBytes, err := xml.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal function module metadata: %w", err)
+	}
+	createEndpoint := fmt.Sprintf("/functions/groups/%s/fmodules", groupLower)
+	if err := c.createObjectMetadata(ctx, createEndpoint, xml.Header+string(xmlBytes)); err != nil {
+		return fmt.Errorf("create function module %s in group %s: %w", name, functionGroup, err)
+	}
+	nameLower := strings.ToLower(name)
+	objectPath := fmt.Sprintf("/functions/groups/%s/fmodules/%s", groupLower, nameLower)
+	return c.createAndPopulate(ctx, createEndpoint, objectPath, objectPath+"/source/main", "FUGR/FF", name, source, source != "")
 }
 
 type includeCreatePayload struct {
@@ -2445,6 +2494,101 @@ func (c *ADTClientImpl) UpdateFunctionGroup(ctx context.Context, name, source st
 	return nil
 }
 
+// updateSourceObject is the shared lock -> setObjectSource -> unlock flow used
+// by all source-text-based Update* methods.
+func (c *ADTClientImpl) updateSourceObject(ctx context.Context, kindLabel, objectPath, sourcePath, name, source string) error {
+	if !c.IsAuthenticated() {
+		return fmt.Errorf("client not authenticated - call Authenticate() first")
+	}
+	if name == "" {
+		return fmt.Errorf("%s name cannot be empty", kindLabel)
+	}
+	if strings.TrimSpace(source) == "" {
+		return fmt.Errorf("source code cannot be empty")
+	}
+
+	c.logger.Info("Updating "+kindLabel, zap.String("name", name), zap.Int("source_length", len(source)))
+
+	lockHandle, corrNr, err := c.lockObject(ctx, objectPath)
+	if err != nil {
+		return fmt.Errorf("failed to lock %s: %w", kindLabel, err)
+	}
+	defer func() {
+		if unlockErr := c.unlockObject(ctx, objectPath, lockHandle); unlockErr != nil {
+			c.logger.Warn("Failed to unlock "+kindLabel, zap.String("name", name), zap.Error(unlockErr))
+		}
+	}()
+
+	if err := c.setObjectSource(ctx, sourcePath, source, lockHandle, corrNr); err != nil {
+		return fmt.Errorf("failed to update %s source: %w", kindLabel, err)
+	}
+
+	c.logger.Info(strings.ToUpper(kindLabel[:1])+kindLabel[1:]+" updated successfully", zap.String("name", name))
+	return nil
+}
+
+// UpdateTable updates an existing ABAP DDIC table's (TABL/DT) source.
+func (c *ADTClientImpl) UpdateTable(ctx context.Context, name, source string) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	nameLower := strings.ToLower(name)
+	objectPath := fmt.Sprintf("/ddic/tables/%s", nameLower)
+	return c.updateSourceObject(ctx, "table", objectPath, objectPath+"/source/main", name, source)
+}
+
+// UpdateStructure updates an existing ABAP DDIC structure's (TABL/DS) source.
+func (c *ADTClientImpl) UpdateStructure(ctx context.Context, name, source string) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	nameLower := strings.ToLower(name)
+	objectPath := fmt.Sprintf("/ddic/structures/%s", nameLower)
+	return c.updateSourceObject(ctx, "structure", objectPath, objectPath+"/source/main", name, source)
+}
+
+// ddlSourceCreatePayload is the create-shell body for a CDS view (DDLS/DF).
+type ddlSourceCreatePayload struct {
+	XMLName     xml.Name        `xml:"ddl:ddlSource"`
+	DdlNS       string          `xml:"xmlns:ddl,attr"`
+	AdtcoreNS   string          `xml:"xmlns:adtcore,attr"`
+	Description string          `xml:"adtcore:description,attr"`
+	Name        string          `xml:"adtcore:name,attr"`
+	Type        string          `xml:"adtcore:type,attr"`
+	Responsible string          `xml:"adtcore:responsible,attr"`
+	PackageRef  classPackageRef `xml:"adtcore:packageRef"`
+}
+
+// CreateDDLS creates a new CDS view (data definition, DDLS/DF) via ADT.
+func (c *ADTClientImpl) CreateDDLS(ctx context.Context, name, description, source string) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	payload := ddlSourceCreatePayload{
+		DdlNS:       "http://www.sap.com/adt/ddic/ddlsources",
+		AdtcoreNS:   "http://www.sap.com/adt/core",
+		Description: description,
+		Name:        name,
+		Type:        "DDLS/DF",
+		Responsible: strings.ToUpper(strings.TrimSpace(c.config.Username)),
+		PackageRef:  classPackageRef{Name: "$TMP"},
+	}
+	xmlBytes, err := xml.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal CDS view metadata: %w", err)
+	}
+	if err := c.createObjectMetadata(ctx, "/ddic/ddl/sources", xml.Header+string(xmlBytes)); err != nil {
+		return fmt.Errorf("create CDS view %s: %w", name, err)
+	}
+	nameLower := strings.ToLower(name)
+	return c.createAndPopulate(ctx, "/ddic/ddl/sources",
+		"/ddic/ddl/sources/"+nameLower,
+		"/ddic/ddl/sources/"+nameLower+"/source/main",
+		"DDLS", name, source, source != "")
+}
+
+// UpdateDDLS updates an existing CDS view's (DDLS/DF) source.
+func (c *ADTClientImpl) UpdateDDLS(ctx context.Context, name, source string) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	nameLower := strings.ToLower(name)
+	objectPath := fmt.Sprintf("/ddic/ddl/sources/%s", nameLower)
+	return c.updateSourceObject(ctx, "CDS view", objectPath, objectPath+"/source/main", name, source)
+}
+
 // objectTypeToURI maps an object type and name to the ADT URI path
 func objectTypeToURI(objectType, objectName string) (string, error) {
 	name := strings.ToLower(objectName)
@@ -2455,12 +2599,16 @@ func objectTypeToURI(objectType, objectName string) (string, error) {
 		return fmt.Sprintf("/sap/bc/adt/oo/classes/%s", name), nil
 	case "INTF", "INTERFACE":
 		return fmt.Sprintf("/sap/bc/adt/oo/interfaces/%s", name), nil
-	case "FUGR", "FUNCTION_GROUP":
+	case "FUGR", "FUNCTION_GROUP", "FUNCTIONGROUP":
 		return fmt.Sprintf("/sap/bc/adt/functions/groups/%s", name), nil
 	case "INCL", "INCLUDE":
 		return fmt.Sprintf("/sap/bc/adt/programs/includes/%s", name), nil
 	case "DDLS", "DATA_DEFINITION":
 		return fmt.Sprintf("/sap/bc/adt/ddic/ddl/sources/%s", name), nil
+	case "TABL", "TABLE":
+		return fmt.Sprintf("/sap/bc/adt/ddic/tables/%s", name), nil
+	case "STRU", "STRUCTURE":
+		return fmt.Sprintf("/sap/bc/adt/ddic/structures/%s", name), nil
 	default:
 		return "", fmt.Errorf("unsupported object type for activation: %s", objectType)
 	}

--- a/internal/adt/create_payload_test.go
+++ b/internal/adt/create_payload_test.go
@@ -1,0 +1,98 @@
+package adt
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+)
+
+// These tests marshal the create-shell XML payloads used by the various
+// Create* methods and assert on the exact type ID / root element abap-adt-api
+// (the reference implementation) expects SAP ADT to receive. They exist
+// because a prior bug shipped CreateFunctionGroup with the function *module*
+// type ID (FUGR/FF) and the wrong root element, which SAP silently rejected
+// with "Data is invalid and could not be converted" only when tested live.
+
+func TestFunctionGroupCreatePayload(t *testing.T) {
+	payload := functionGroupCreatePayload{
+		FgroupNS:    "http://www.sap.com/adt/functions/groups",
+		AdtcoreNS:   "http://www.sap.com/adt/core",
+		Description: "test group",
+		Name:        "ZTEST_FG",
+		Type:        "FUGR/F",
+		Responsible: "DEVELOPER",
+		PackageRef:  classPackageRef{Name: "$TMP"},
+	}
+	out, err := xml.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	xmlStr := string(out)
+
+	if !strings.Contains(xmlStr, `<group:abapFunctionGroup`) {
+		t.Errorf("expected root element group:abapFunctionGroup, got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `adtcore:type="FUGR/F"`) {
+		t.Errorf("expected adtcore:type=\"FUGR/F\" (function GROUP, not module), got: %s", xmlStr)
+	}
+	if strings.Contains(xmlStr, `FUGR/FF`) {
+		t.Errorf("function group payload must not use the function MODULE type ID FUGR/FF: %s", xmlStr)
+	}
+}
+
+func TestFunctionModuleCreatePayload(t *testing.T) {
+	payload := functionModuleCreatePayload{
+		FmoduleNS:   "http://www.sap.com/adt/functions/fmodules",
+		AdtcoreNS:   "http://www.sap.com/adt/core",
+		Description: "test module",
+		Name:        "ZTEST_FM",
+		Type:        "FUGR/FF",
+		ContainerRef: functionContainerRef{
+			Name: "ZTEST_FG",
+			Type: "FUGR/F",
+			URI:  "/sap/bc/adt/functions/groups/ztest_fg",
+		},
+	}
+	out, err := xml.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	xmlStr := string(out)
+
+	if !strings.Contains(xmlStr, `<fmodule:abapFunctionModule`) {
+		t.Errorf("expected root element fmodule:abapFunctionModule, got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `adtcore:type="FUGR/FF"`) {
+		t.Errorf("expected adtcore:type=\"FUGR/FF\", got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `<adtcore:containerRef`) {
+		t.Errorf("function module create must reference its containing group via containerRef, got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `adtcore:name="ZTEST_FG"`) {
+		t.Errorf("containerRef must name the containing function group, got: %s", xmlStr)
+	}
+}
+
+func TestDDLSourceCreatePayload(t *testing.T) {
+	payload := ddlSourceCreatePayload{
+		DdlNS:       "http://www.sap.com/adt/ddic/ddlsources",
+		AdtcoreNS:   "http://www.sap.com/adt/core",
+		Description: "test CDS view",
+		Name:        "ZTEST_CDS",
+		Type:        "DDLS/DF",
+		Responsible: "DEVELOPER",
+		PackageRef:  classPackageRef{Name: "$TMP"},
+	}
+	out, err := xml.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	xmlStr := string(out)
+
+	if !strings.Contains(xmlStr, `<ddl:ddlSource`) {
+		t.Errorf("expected root element ddl:ddlSource, got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `adtcore:type="DDLS/DF"`) {
+		t.Errorf("expected adtcore:type=\"DDLS/DF\", got: %s", xmlStr)
+	}
+}

--- a/internal/adt/object_type_uri_test.go
+++ b/internal/adt/object_type_uri_test.go
@@ -1,0 +1,51 @@
+package adt
+
+import "testing"
+
+// TestObjectTypeToURI covers every alias the REST layer (rest/server/server.go)
+// accepts for object_type across get/create/save handlers. A prior bug let
+// "FUNCTIONGROUP" through everywhere except here, so ActivateObject and
+// SyntaxCheck rejected it with "unsupported object type for activation" even
+// though it read/created/saved fine.
+func TestObjectTypeToURI(t *testing.T) {
+	cases := []struct {
+		objectType string
+		name       string
+		wantURI    string
+	}{
+		{"PROG", "zfoo", "/sap/bc/adt/programs/programs/zfoo"},
+		{"PROGRAM", "zfoo", "/sap/bc/adt/programs/programs/zfoo"},
+		{"CLAS", "zcl_foo", "/sap/bc/adt/oo/classes/zcl_foo"},
+		{"CLASS", "zcl_foo", "/sap/bc/adt/oo/classes/zcl_foo"},
+		{"INTF", "zif_foo", "/sap/bc/adt/oo/interfaces/zif_foo"},
+		{"INTERFACE", "zif_foo", "/sap/bc/adt/oo/interfaces/zif_foo"},
+		{"FUGR", "zfg", "/sap/bc/adt/functions/groups/zfg"},
+		{"FUNCTION_GROUP", "zfg", "/sap/bc/adt/functions/groups/zfg"},
+		{"FUNCTIONGROUP", "zfg", "/sap/bc/adt/functions/groups/zfg"},
+		{"INCL", "zincl", "/sap/bc/adt/programs/includes/zincl"},
+		{"INCLUDE", "zincl", "/sap/bc/adt/programs/includes/zincl"},
+		{"DDLS", "zcds", "/sap/bc/adt/ddic/ddl/sources/zcds"},
+		{"DATA_DEFINITION", "zcds", "/sap/bc/adt/ddic/ddl/sources/zcds"},
+		{"TABL", "ztab", "/sap/bc/adt/ddic/tables/ztab"},
+		{"TABLE", "ztab", "/sap/bc/adt/ddic/tables/ztab"},
+		{"STRU", "zstru", "/sap/bc/adt/ddic/structures/zstru"},
+		{"STRUCTURE", "zstru", "/sap/bc/adt/ddic/structures/zstru"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.objectType, func(t *testing.T) {
+			got, err := objectTypeToURI(tc.objectType, tc.name)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantURI {
+				t.Errorf("objectTypeToURI(%q, %q) = %q, want %q", tc.objectType, tc.name, got, tc.wantURI)
+			}
+		})
+	}
+}
+
+func TestObjectTypeToURI_Unsupported(t *testing.T) {
+	if _, err := objectTypeToURI("BOGUS", "x"); err == nil {
+		t.Fatal("expected error for unsupported object type")
+	}
+}

--- a/rest/server/fake_adt_client_test.go
+++ b/rest/server/fake_adt_client_test.go
@@ -20,8 +20,15 @@ type fakeADTClient struct {
 	searchObjectsFn      func(ctx context.Context, pattern string, objectTypes []string) (*types.ADTSearchResult, error)
 	updateProgramFn      func(ctx context.Context, name, source string) error
 	updateClassFn        func(ctx context.Context, name, source string) error
+	updateFunctionFn     func(ctx context.Context, functionName, functionGroup, source string) error
+	updateTableFn        func(ctx context.Context, name, source string) error
+	updateStructureFn    func(ctx context.Context, name, source string) error
+	updateDDLSFn         func(ctx context.Context, name, source string) error
 	createProgramFn      func(ctx context.Context, name, description, packageName, source string) error
 	createClassFn        func(ctx context.Context, name, description, packageName, source string) error
+	createFunctionFn     func(ctx context.Context, name, functionGroup, description, source string) error
+	createDDLSFn         func(ctx context.Context, name, description, source string) error
+	getTypeInfoFn        func(ctx context.Context, typeName string) (*types.ADTTypeInfo, error)
 	activateObjectFn     func(ctx context.Context, objectType, objectName string) (*types.ActivationResult, error)
 	runUnitTestsFn       func(ctx context.Context, objectType, objectName string) (*types.UnitTestResult, error)
 	syntaxCheckFn        func(ctx context.Context, objectType, objectName, source string) (*types.SyntaxCheckResult, error)
@@ -101,6 +108,18 @@ func (f *fakeADTClient) CreateTable(ctx context.Context, name, description, sour
 func (f *fakeADTClient) CreateFunctionGroup(ctx context.Context, name, description, source string) error {
 	return nil
 }
+func (f *fakeADTClient) CreateFunction(ctx context.Context, name, functionGroup, description, source string) error {
+	if f.createFunctionFn != nil {
+		return f.createFunctionFn(ctx, name, functionGroup, description, source)
+	}
+	return nil
+}
+func (f *fakeADTClient) CreateDDLS(ctx context.Context, name, description, source string) error {
+	if f.createDDLSFn != nil {
+		return f.createDDLSFn(ctx, name, description, source)
+	}
+	return nil
+}
 func (f *fakeADTClient) UpdateProgram(ctx context.Context, name, source string) error {
 	if f.updateProgramFn != nil {
 		return f.updateProgramFn(ctx, name, source)
@@ -118,9 +137,30 @@ func (f *fakeADTClient) UpdateInterface(ctx context.Context, name, source string
 	return nil
 }
 func (f *fakeADTClient) UpdateFunction(ctx context.Context, functionName, functionGroup, source string) error {
+	if f.updateFunctionFn != nil {
+		return f.updateFunctionFn(ctx, functionName, functionGroup, source)
+	}
 	return nil
 }
 func (f *fakeADTClient) UpdateFunctionGroup(ctx context.Context, name, source string) error {
+	return nil
+}
+func (f *fakeADTClient) UpdateTable(ctx context.Context, name, source string) error {
+	if f.updateTableFn != nil {
+		return f.updateTableFn(ctx, name, source)
+	}
+	return nil
+}
+func (f *fakeADTClient) UpdateStructure(ctx context.Context, name, source string) error {
+	if f.updateStructureFn != nil {
+		return f.updateStructureFn(ctx, name, source)
+	}
+	return nil
+}
+func (f *fakeADTClient) UpdateDDLS(ctx context.Context, name, source string) error {
+	if f.updateDDLSFn != nil {
+		return f.updateDDLSFn(ctx, name, source)
+	}
 	return nil
 }
 
@@ -191,6 +231,9 @@ func (f *fakeADTClient) FormatSource(ctx context.Context, source string) (string
 }
 
 func (f *fakeADTClient) GetTypeInfo(ctx context.Context, typeName string) (*types.ADTTypeInfo, error) {
+	if f.getTypeInfoFn != nil {
+		return f.getTypeInfoFn(ctx, typeName)
+	}
 	return &types.ADTTypeInfo{TypeName: typeName}, nil
 }
 func (f *fakeADTClient) GetTransaction(ctx context.Context, transactionName string) (*types.ADTTransactionInfo, error) {

--- a/rest/server/server.go
+++ b/rest/server/server.go
@@ -253,6 +253,10 @@ func (rs *RestServer) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 		result, err = c.GetDDLSource(ctx, objectName)
 	case "FUNCTIONGROUP", "FUGR":
 		result, err = c.GetFunctionGroup(ctx, objectName)
+	case "DOMAIN", "DOMA":
+		result, err = c.GetTypeInfo(ctx, objectName)
+	case "DATA_ELEMENT", "DTEL":
+		result, err = c.GetTypeInfo(ctx, objectName)
 	case "PACKAGE", "PACK":
 		result, err = c.GetPackageContents(ctx, objectName)
 	default:
@@ -318,6 +322,12 @@ func (rs *RestServer) createObjectHandler(w http.ResponseWriter, r *http.Request
 			saveErr = c.UpdateFunction(ctx, objectName, strings.ToUpper(req.Args[0]), req.Source)
 		case "FUNCTIONGROUP", "FUGR":
 			saveErr = c.UpdateFunctionGroup(ctx, objectName, req.Source)
+		case "TABLE", "TABL":
+			saveErr = c.UpdateTable(ctx, objectName, req.Source)
+		case "STRUCTURE", "STRU":
+			saveErr = c.UpdateStructure(ctx, objectName, req.Source)
+		case "DDLS", "DATA_DEFINITION":
+			saveErr = c.UpdateDDLS(ctx, objectName, req.Source)
 		default:
 			rs.sendError(w, "unsupported object type for save: "+objectType, http.StatusBadRequest)
 			return
@@ -370,6 +380,14 @@ func (rs *RestServer) createObjectHandler(w http.ResponseWriter, r *http.Request
 		err = c.CreateTable(ctx, objectName, description, sourceCode)
 	case "FUNCTIONGROUP", "FUGR":
 		err = c.CreateFunctionGroup(ctx, objectName, description, sourceCode)
+	case "FUNCTION", "FUNC":
+		if len(req.Args) == 0 {
+			rs.sendError(w, "function group required in args for function modules", http.StatusBadRequest)
+			return
+		}
+		err = c.CreateFunction(ctx, objectName, strings.ToUpper(req.Args[0]), description, sourceCode)
+	case "DDLS", "DATA_DEFINITION":
+		err = c.CreateDDLS(ctx, objectName, description, sourceCode)
 	default:
 		rs.sendError(w, "unsupported object type for creation: "+objectType, http.StatusBadRequest)
 		return
@@ -579,6 +597,12 @@ func (rs *RestServer) saveObjectHandler(w http.ResponseWriter, r *http.Request) 
 		err = c.UpdateFunction(ctx, objectName, strings.ToUpper(req.Args[0]), req.Source)
 	case "FUNCTIONGROUP", "FUGR":
 		err = c.UpdateFunctionGroup(ctx, objectName, req.Source)
+	case "TABLE", "TABL":
+		err = c.UpdateTable(ctx, objectName, req.Source)
+	case "STRUCTURE", "STRU":
+		err = c.UpdateStructure(ctx, objectName, req.Source)
+	case "DDLS", "DATA_DEFINITION":
+		err = c.UpdateDDLS(ctx, objectName, req.Source)
 	default:
 		rs.sendError(w, "unsupported object type for save: "+objectType, http.StatusBadRequest)
 		return

--- a/rest/server/server_test.go
+++ b/rest/server/server_test.go
@@ -110,6 +110,51 @@ func TestGetObjectHandler(t *testing.T) {
 		}
 	})
 
+	t.Run("domain", func(t *testing.T) {
+		var gotType string
+		fake := &fakeADTClient{
+			getTypeInfoFn: func(ctx context.Context, typeName string) (*types.ADTTypeInfo, error) {
+				gotType = typeName
+				return &types.ADTTypeInfo{TypeName: typeName, TypeKind: "DOMAIN"}, nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/get", map[string]string{
+			"object_type": "domain",
+			"object_name": "zwels",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if gotType != "ZWELS" {
+			t.Errorf("expected uppercased type name passed through, got %q", gotType)
+		}
+		data := decodeSuccess[types.ADTTypeInfo](t, rec)
+		if data.TypeKind != "DOMAIN" {
+			t.Errorf("expected TypeKind DOMAIN, got %q", data.TypeKind)
+		}
+	})
+
+	t.Run("data element", func(t *testing.T) {
+		fake := &fakeADTClient{
+			getTypeInfoFn: func(ctx context.Context, typeName string) (*types.ADTTypeInfo, error) {
+				return &types.ADTTypeInfo{TypeName: typeName, TypeKind: "DATA_ELEMENT"}, nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/get", map[string]string{
+			"object_type": "data_element",
+			"object_name": "zdtel_tims",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		data := decodeSuccess[types.ADTTypeInfo](t, rec)
+		if data.TypeKind != "DATA_ELEMENT" {
+			t.Errorf("expected TypeKind DATA_ELEMENT, got %q", data.TypeKind)
+		}
+	})
+
 	t.Run("missing fields", func(t *testing.T) {
 		rs := newTestServer(t, &fakeADTClient{})
 		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/get", map[string]string{"object_type": "program"})
@@ -179,12 +224,82 @@ func TestCreateObjectHandler(t *testing.T) {
 	t.Run("unsupported type", func(t *testing.T) {
 		rs := newTestServer(t, &fakeADTClient{})
 		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/create", map[string]string{
-			"object_type": "function",
+			"object_type": "bogus",
 			"object_name": "x",
+			"description": "force create path, not save-mode",
 		})
-		// FUNCTION has no creation case in the handler switch (only update).
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("function module requires group in args", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/create", map[string]string{
+			"object_type": "function",
+			"object_name": "zabpb_fm1",
+			"description": "test FM",
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("function module create with group", func(t *testing.T) {
+		var gotName, gotGroup string
+		fake := &fakeADTClient{
+			createFunctionFn: func(ctx context.Context, name, functionGroup, description, source string) error {
+				gotName, gotGroup = name, functionGroup
+				return nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/create", map[string]any{
+			"object_type": "function",
+			"object_name": "zabpb_fm1",
+			"description": "test FM",
+			"args":        []string{"zabpb_fg1"},
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if gotName != "ZABPB_FM1" || gotGroup != "ZABPB_FG1" {
+			t.Errorf("expected name=ZABPB_FM1 group=ZABPB_FG1, got name=%q group=%q", gotName, gotGroup)
+		}
+	})
+
+	t.Run("function group create", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/create", map[string]string{
+			"object_type": "functiongroup",
+			"object_name": "zabpb_fg1",
+			"description": "test FG",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("ddls create", func(t *testing.T) {
+		var gotName, gotSource string
+		fake := &fakeADTClient{
+			createDDLSFn: func(ctx context.Context, name, description, source string) error {
+				gotName, gotSource = name, source
+				return nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/create", map[string]string{
+			"object_type": "ddls",
+			"object_name": "zabpb_cds1",
+			"description": "test CDS",
+			"source":      "define view ZABPB_CDS1 as select from t000 { key mandt }",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if gotName != "ZABPB_CDS1" || gotSource == "" {
+			t.Errorf("expected name=ZABPB_CDS1 with source, got name=%q source=%q", gotName, gotSource)
 		}
 	})
 }
@@ -222,6 +337,107 @@ func TestSaveObjectHandler(t *testing.T) {
 		})
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("expected 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("updates table", func(t *testing.T) {
+		var gotName string
+		fake := &fakeADTClient{
+			updateTableFn: func(ctx context.Context, name, source string) error {
+				gotName = name
+				return nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/save", map[string]string{
+			"object_type": "table",
+			"object_name": "zabpbt1",
+			"source":      "define table zabpbt1 { key client : mandt not null; }",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if gotName != "ZABPBT1" {
+			t.Errorf("expected uppercased name, got %q", gotName)
+		}
+	})
+
+	t.Run("updates structure", func(t *testing.T) {
+		var called bool
+		fake := &fakeADTClient{
+			updateStructureFn: func(ctx context.Context, name, source string) error {
+				called = true
+				return nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/save", map[string]string{
+			"object_type": "structure",
+			"object_name": "zabpbs1",
+			"source":      "define structure zabpbs1 { id : abap.char(10); }",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if !called {
+			t.Error("expected UpdateStructure to be called")
+		}
+	})
+
+	t.Run("updates ddls", func(t *testing.T) {
+		var called bool
+		fake := &fakeADTClient{
+			updateDDLSFn: func(ctx context.Context, name, source string) error {
+				called = true
+				return nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/save", map[string]string{
+			"object_type": "ddls",
+			"object_name": "zabpb_cds1",
+			"source":      "define view ZABPB_CDS1 as select from t000 { key mandt }",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if !called {
+			t.Error("expected UpdateDDLS to be called")
+		}
+	})
+
+	t.Run("updates function module", func(t *testing.T) {
+		var gotName, gotGroup string
+		fake := &fakeADTClient{
+			updateFunctionFn: func(ctx context.Context, functionName, functionGroup, source string) error {
+				gotName, gotGroup = functionName, functionGroup
+				return nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/save", map[string]any{
+			"object_type": "function",
+			"object_name": "zabpb_fm1",
+			"source":      "FUNCTION zabpb_fm1.\nENDFUNCTION.",
+			"args":        []string{"zabpb_fg1"},
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if gotName != "ZABPB_FM1" || gotGroup != "ZABPB_FG1" {
+			t.Errorf("expected name=ZABPB_FM1 group=ZABPB_FG1, got name=%q group=%q", gotName, gotGroup)
+		}
+	})
+
+	t.Run("function module requires group in args", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/save", map[string]string{
+			"object_type": "function",
+			"object_name": "zabpb_fm1",
+			"source":      "FUNCTION zabpb_fm1.\nENDFUNCTION.",
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
 		}
 	})
 }

--- a/types/adt.go
+++ b/types/adt.go
@@ -188,12 +188,17 @@ type SourceWriter interface {
 	CreateStructure(ctx context.Context, name, description, source string) error
 	CreateTable(ctx context.Context, name, description, source string) error
 	CreateFunctionGroup(ctx context.Context, name, description, source string) error
+	CreateFunction(ctx context.Context, name, functionGroup, description, source string) error
+	CreateDDLS(ctx context.Context, name, description, source string) error
 	UpdateProgram(ctx context.Context, name, source string) error
 	UpdateClass(ctx context.Context, name, source string) error
 	UpdateInclude(ctx context.Context, name, source string) error
 	UpdateInterface(ctx context.Context, name, source string) error
 	UpdateFunction(ctx context.Context, functionName, functionGroup, source string) error
 	UpdateFunctionGroup(ctx context.Context, name, source string) error
+	UpdateTable(ctx context.Context, name, source string) error
+	UpdateStructure(ctx context.Context, name, source string) error
+	UpdateDDLS(ctx context.Context, name, source string) error
 }
 
 // PackageNode is a single entry returned by the nodestructure endpoint.


### PR DESCRIPTION
## Summary

TDD-driven parity pass against [marcellourbani/abap-adt-api](https://github.com/marcellourbani/abap-adt-api) (the reference ADT client), scoped to: program, class, function module, function group, DDIC objects (table, structure, domain, data element), CDS views. Plan and detailed findings in `docs/OBJECT_TYPE_PARITY_PLAN.md`.

Methodology: for every object type, tested search → read → edit → create live against a real SAP system (`abap.bluefunda.com`) via a locally-run `abaper serve`, using disposable `ZABPB_*`-prefixed test objects. Every fix below was found and verified this way, not just unit-tested against a fake.

### Fixes
- **Domain/data-element read** now reachable via REST (`getObjectHandler` had no case for them). Also fixed `GetTypeInfo`, which was hitting a nonexistent `/ddic/domains/{n}/source/main` endpoint and the wrong `Accept` header for data elements — confirmed live these objects have no source/main representation, only a plain-GET metadata resource.
- **`CreateFunctionGroup` was silently broken**: it sent `adtcore:type="FUGR/FF"` (the function *module* type ID) and root element `fgroup:functionGroup` instead of `FUGR/F` / `group:abapFunctionGroup`. SAP rejected every call with `ExceptionInvalidData — Data is invalid and could not be converted`.
- **`CreateFunction`** (function module create within a group) added — was entirely missing; only update existed.
- **`UpdateTable` / `UpdateStructure`** added — these DDIC objects could be created but never edited again.
- **`CreateDDLS` / `UpdateDDLS`** (CDS views) added — read already existed.
- **`objectTypeToURI` bug** (found via live activation test, not in the original scope): accepted `FUGR`/`FUNCTION_GROUP` but not `FUNCTIONGROUP`, the alias every other REST handler in this codebase accepts. Activating a function group created through the REST API failed with "unsupported object type for activation".

### Deferred
Domain/data-element **create/update**: confirmed live that SAP models these via a structured-properties XML API (`getDomainProperties`/`setDomainProperties` in the reference client) distinct from the source-text convention every other object type here uses. Large enough to warrant its own follow-up — see plan doc.

Traces/snapshots remain explicitly out of scope per prior parity work (zero client usage, PR #92/#98).

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` — all pass, including new unit tests:
  - `internal/adt/create_payload_test.go` — regression tests for the FUGR/F vs FUGR/FF payload bug and the new function-module/DDLS create payloads
  - `internal/adt/object_type_uri_test.go` — covers every REST alias including the FUNCTIONGROUP fix
  - `rest/server/server_test.go` — new/extended cases for domain/data-element get, function module create/save (with and without required group arg), function group create, DDLS create/save, table/structure save
- [x] Live-verified end-to-end (create → read → update → activate) against `abap.bluefunda.com` for every changed/added capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)