### PR TITLE
feat(adt): domain/data-element create+update via structured-properties flow

### DIFF
--- a/docs/OBJECT_TYPE_PARITY_PLAN.md
+++ b/docs/OBJECT_TYPE_PARITY_PLAN.md
@@ -131,3 +131,32 @@ genuinely different, larger feature (new request/response types, no reuse of
 `lockObject`/`setObjectSource`/`createAndPopulate`). Recommend a separate
 follow-up issue/PR scoped specifically to this, rather than folding it into
 this change.
+
+## Follow-up (2026-07-02): Domain / Data Element create+update — WIP
+
+Branch `feat/ddic-domain-dtel-crud`. Implements `CreateDomain`/`UpdateDomain`/
+`CreateDataElement`/`UpdateDataElement` (types + `internal/adt` + REST wiring on
+create/save via `domain_properties`/`data_element_properties` request fields).
+
+**Live-proven manually (raw curl):** the full flow works —
+create-shell POST → lock → PUT structured properties → unlock → activate —
+verified end-to-end for both a domain (CHAR 10, `ZABPB_DOM1`) and a data element
+referencing it (`ZABPB_DTEL1`), both reaching `version="active"`. Findings:
+- Domains/data elements have NO `/source/main`; they use a plain-GET metadata
+  resource and a PUT of a structured XML body to the object URL.
+- Activation MUST happen AFTER unlock (locked activation → "User X is currently
+  editing").
+- The data-element PUT body is strict: every `dtel:*` element must be present in
+  the exact reference order, including the `*FieldMaxLength` elements.
+
+**Known open issue (why this isn't done):** through the Go path, create/update
+run without error and the properties PUT succeeds, but the object is left
+`version="new"` (inactive). The REST `activate` call returns `activated:true`
+yet SAP does not actually activate it — i.e. an empty activation worklist.
+Suspect the `ActivationRequest` XML shape (`<objectReferences xmlns=...>` with
+un-prefixed `objectReference`/`uri`/`name`) differs from the working manual body
+(`adtcore:`-prefixed `objectReferences`/`objectReference`/`uri`/`name`). Source
+objects activate fine with the current shape, so this only bites DDIC property
+objects. Next step: build the activation body with `adtcore:`-prefixed elements
+(matching the proven curl) for these types, or reuse the exact reference shape,
+then re-verify `version="active"` live.

--- a/internal/adt/client.go
+++ b/internal/adt/client.go
@@ -2589,6 +2589,277 @@ func (c *ADTClientImpl) UpdateDDLS(ctx context.Context, name, source string) err
 	return c.updateSourceObject(ctx, "CDS view", objectPath, objectPath+"/source/main", name, source)
 }
 
+// --- DDIC property objects (domains, data elements) ---
+//
+// Domains and data elements are not source-text objects: they are defined by
+// structured properties. The flow, verified live against SAP ADT, is:
+//   create-shell (POST) -> lock -> PUT properties -> unlock -> activate.
+// Activation must happen AFTER unlock (SAP rejects activation of a locked DDIC
+// property object with "User X is currently editing"), which is why this does
+// not reuse createAndPopulate (that activates while holding the lock).
+
+type domainTypeInfo struct {
+	Datatype string `xml:"doma:datatype"`
+	Length   int    `xml:"doma:length"`
+	Decimals int    `xml:"doma:decimals"`
+}
+
+type domainOutputInfo struct {
+	Length         int    `xml:"doma:length"`
+	Style          string `xml:"doma:style"`
+	ConversionExit string `xml:"doma:conversionExit"`
+	SignExists     bool   `xml:"doma:signExists"`
+	Lowercase      bool   `xml:"doma:lowercase"`
+	AmpmFormat     bool   `xml:"doma:ampmFormat"`
+}
+
+type domainContent struct {
+	TypeInfo   domainTypeInfo   `xml:"doma:typeInformation"`
+	OutputInfo domainOutputInfo `xml:"doma:outputInformation"`
+}
+
+type domainPayload struct {
+	XMLName     xml.Name        `xml:"doma:domain"`
+	DomaNS      string          `xml:"xmlns:doma,attr"`
+	AdtcoreNS   string          `xml:"xmlns:adtcore,attr"`
+	Description string          `xml:"adtcore:description,attr"`
+	Language    string          `xml:"adtcore:language,attr"`
+	Name        string          `xml:"adtcore:name,attr"`
+	Type        string          `xml:"adtcore:type,attr"`
+	Version     string          `xml:"adtcore:version,attr,omitempty"`
+	MasterLang  string          `xml:"adtcore:masterLanguage,attr"`
+	Responsible string          `xml:"adtcore:responsible,attr"`
+	PackageRef  classPackageRef `xml:"adtcore:packageRef"`
+	Content     *domainContent  `xml:"doma:content"` // nil for the create shell
+}
+
+// CreateDomain creates a DDIC domain (DOMA/DD) with the given properties.
+func (c *ADTClientImpl) CreateDomain(ctx context.Context, name string, props types.DomainProperties) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	shell := domainPayload{
+		DomaNS:      "http://www.sap.com/dictionary/domain",
+		AdtcoreNS:   "http://www.sap.com/adt/core",
+		Description: props.Description,
+		Language:    "EN",
+		Name:        name,
+		Type:        "DOMA/DD",
+		MasterLang:  "EN",
+		Responsible: strings.ToUpper(strings.TrimSpace(c.config.Username)),
+		PackageRef:  classPackageRef{Name: "$TMP"},
+	}
+	xmlBytes, err := xml.Marshal(shell)
+	if err != nil {
+		return fmt.Errorf("marshal domain shell: %w", err)
+	}
+	if err := c.createObjectMetadata(ctx, "/ddic/domains", xml.Header+string(xmlBytes)); err != nil {
+		return fmt.Errorf("create domain %s: %w", name, err)
+	}
+	return c.UpdateDomain(ctx, name, props)
+}
+
+// UpdateDomain sets the properties of an existing DDIC domain and activates it.
+func (c *ADTClientImpl) UpdateDomain(ctx context.Context, name string, props types.DomainProperties) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	outputLen := props.OutputLength
+	if outputLen == 0 {
+		outputLen = props.Length
+	}
+	body := domainPayload{
+		DomaNS:      "http://www.sap.com/dictionary/domain",
+		AdtcoreNS:   "http://www.sap.com/adt/core",
+		Description: props.Description,
+		Language:    "EN",
+		Name:        name,
+		Type:        "DOMA/DD",
+		Version:     "inactive",
+		MasterLang:  "EN",
+		Responsible: strings.ToUpper(strings.TrimSpace(c.config.Username)),
+		PackageRef:  classPackageRef{Name: "$TMP"},
+		Content: &domainContent{
+			TypeInfo: domainTypeInfo{
+				Datatype: strings.ToUpper(strings.TrimSpace(props.DataType)),
+				Length:   props.Length,
+				Decimals: props.Decimals,
+			},
+			OutputInfo: domainOutputInfo{
+				Length:         outputLen,
+				Style:          "00",
+				ConversionExit: props.ConversionExit,
+				Lowercase:      props.LowerCase,
+			},
+		},
+	}
+	xmlBytes, err := xml.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal domain properties: %w", err)
+	}
+	return c.setPropertiesAndActivate(ctx, "DOMAIN", "/ddic/domains/"+strings.ToLower(name), name, xml.Header+string(xmlBytes))
+}
+
+type dataElementInner struct {
+	TypeKind         string `xml:"dtel:typeKind"`
+	TypeName         string `xml:"dtel:typeName"`
+	DataType         string `xml:"dtel:dataType"`
+	DataTypeLength   int    `xml:"dtel:dataTypeLength"`
+	DataTypeDecimals int    `xml:"dtel:dataTypeDecimals"`
+	ShortLabel       string `xml:"dtel:shortFieldLabel"`
+	ShortLength      int    `xml:"dtel:shortFieldLength"`
+	ShortMaxLength   int    `xml:"dtel:shortFieldMaxLength"`
+	MediumLabel      string `xml:"dtel:mediumFieldLabel"`
+	MediumLength     int    `xml:"dtel:mediumFieldLength"`
+	MediumMaxLength  int    `xml:"dtel:mediumFieldMaxLength"`
+	LongLabel        string `xml:"dtel:longFieldLabel"`
+	LongLength       int    `xml:"dtel:longFieldLength"`
+	LongMaxLength    int    `xml:"dtel:longFieldMaxLength"`
+	HeadingLabel     string `xml:"dtel:headingFieldLabel"`
+	HeadingLength    int    `xml:"dtel:headingFieldLength"`
+	HeadingMaxLength int    `xml:"dtel:headingFieldMaxLength"`
+	SearchHelp       string `xml:"dtel:searchHelp"`
+	SearchHelpParam  string `xml:"dtel:searchHelpParameter"`
+	SetGetParam      string `xml:"dtel:setGetParameter"`
+	DefaultComponent string `xml:"dtel:defaultComponentName"`
+	DeactInputHist   bool   `xml:"dtel:deactivateInputHistory"`
+	ChangeDocument   bool   `xml:"dtel:changeDocument"`
+	LeftToRight      bool   `xml:"dtel:leftToRightDirection"`
+	DeactBIDI        bool   `xml:"dtel:deactivateBIDIFiltering"`
+}
+
+type dataElementPayload struct {
+	XMLName     xml.Name          `xml:"blue:wbobj"`
+	AdtcoreNS   string            `xml:"xmlns:adtcore,attr"`
+	BlueNS      string            `xml:"xmlns:blue,attr"`
+	DtelNS      string            `xml:"xmlns:dtel,attr,omitempty"`
+	Description string            `xml:"adtcore:description,attr"`
+	Language    string            `xml:"adtcore:language,attr"`
+	Name        string            `xml:"adtcore:name,attr"`
+	Type        string            `xml:"adtcore:type,attr"`
+	Version     string            `xml:"adtcore:version,attr,omitempty"`
+	MasterLang  string            `xml:"adtcore:masterLanguage,attr"`
+	Responsible string            `xml:"adtcore:responsible,attr"`
+	PackageRef  classPackageRef   `xml:"adtcore:packageRef"`
+	DataElement *dataElementInner `xml:"dtel:dataElement"` // nil for the create shell
+}
+
+// CreateDataElement creates a DDIC data element (DTEL/DE) with the given properties.
+func (c *ADTClientImpl) CreateDataElement(ctx context.Context, name string, props types.DataElementProperties) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	shell := dataElementPayload{
+		AdtcoreNS:   "http://www.sap.com/adt/core",
+		BlueNS:      "http://www.sap.com/wbobj/dictionary/dtel",
+		Description: props.Description,
+		Language:    "EN",
+		Name:        name,
+		Type:        "DTEL/DE",
+		MasterLang:  "EN",
+		Responsible: strings.ToUpper(strings.TrimSpace(c.config.Username)),
+		PackageRef:  classPackageRef{Name: "$TMP"},
+	}
+	xmlBytes, err := xml.Marshal(shell)
+	if err != nil {
+		return fmt.Errorf("marshal data element shell: %w", err)
+	}
+	if err := c.createObjectMetadata(ctx, "/ddic/dataelements", xml.Header+string(xmlBytes)); err != nil {
+		return fmt.Errorf("create data element %s: %w", name, err)
+	}
+	return c.UpdateDataElement(ctx, name, props)
+}
+
+// UpdateDataElement sets the properties of an existing data element and activates it.
+func (c *ADTClientImpl) UpdateDataElement(ctx context.Context, name string, props types.DataElementProperties) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	inner := dataElementInner{
+		ShortLabel:   props.ShortLabel,
+		ShortLength:  10,
+		ShortMaxLength:   10,
+		MediumLabel:  props.MediumLabel,
+		MediumLength: 20,
+		MediumMaxLength:  20,
+		LongLabel:    props.LongLabel,
+		LongLength:   40,
+		LongMaxLength:    40,
+		HeadingLabel: props.HeadingLabel,
+		HeadingLength:    55,
+		HeadingMaxLength: 55,
+	}
+	if strings.TrimSpace(props.DomainName) != "" {
+		inner.TypeKind = "domain"
+		inner.TypeName = strings.ToUpper(strings.TrimSpace(props.DomainName))
+	} else {
+		inner.TypeKind = "predefinedAbapType"
+		inner.DataType = strings.ToUpper(strings.TrimSpace(props.DataType))
+		inner.DataTypeLength = props.Length
+		inner.DataTypeDecimals = props.Decimals
+	}
+	body := dataElementPayload{
+		AdtcoreNS:   "http://www.sap.com/adt/core",
+		BlueNS:      "http://www.sap.com/wbobj/dictionary/dtel",
+		DtelNS:      "http://www.sap.com/adt/dictionary/dataelements",
+		Description: props.Description,
+		Language:    "EN",
+		Name:        name,
+		Type:        "DTEL/DE",
+		Version:     "inactive",
+		MasterLang:  "EN",
+		Responsible: strings.ToUpper(strings.TrimSpace(c.config.Username)),
+		PackageRef:  classPackageRef{Name: "$TMP"},
+		DataElement: &inner,
+	}
+	xmlBytes, err := xml.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal data element properties: %w", err)
+	}
+	return c.setPropertiesAndActivate(ctx, "DATA_ELEMENT", "/ddic/dataelements/"+strings.ToLower(name), name, xml.Header+string(xmlBytes))
+}
+
+// setPropertiesAndActivate runs the lock -> PUT properties -> unlock -> activate
+// flow shared by DDIC property objects. Activation happens after unlock.
+func (c *ADTClientImpl) setPropertiesAndActivate(ctx context.Context, objectType, objectPath, name, body string) error {
+	if !c.IsAuthenticated() {
+		return fmt.Errorf("client not authenticated - call Authenticate() first")
+	}
+	lockHandle, _, err := c.lockObject(ctx, objectPath)
+	if err != nil {
+		return fmt.Errorf("failed to lock %s: %w", name, err)
+	}
+	if err := c.putObjectProperties(ctx, objectPath, body, lockHandle); err != nil {
+		if unlockErr := c.unlockObject(ctx, objectPath, lockHandle); unlockErr != nil {
+			c.logger.Warn("Failed to unlock after property write error", zap.String("name", name), zap.Error(unlockErr))
+		}
+		return fmt.Errorf("failed to set properties for %s: %w", name, err)
+	}
+	if err := c.unlockObject(ctx, objectPath, lockHandle); err != nil {
+		return fmt.Errorf("failed to unlock %s: %w", name, err)
+	}
+	if _, err := c.ActivateObject(ctx, objectType, name); err != nil {
+		return fmt.Errorf("failed to activate %s: %w", name, err)
+	}
+	c.logger.Info("DDIC property object saved and activated", zap.String("type", objectType), zap.String("name", name))
+	return nil
+}
+
+// putObjectProperties PUTs a structured-properties XML body to a DDIC object URL
+// (not its /source/main), under an active lock.
+func (c *ADTClientImpl) putObjectProperties(ctx context.Context, objectPath, body, lockHandle string) error {
+	url := fmt.Sprintf("%s%s?lockHandle=%s", c.baseURL, objectPath, lockHandle)
+	req, err := http.NewRequestWithContext(ctx, "PUT", url, strings.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create properties request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	req.Header.Set("Content-Type", "application/*")
+	req.Header.Set("Accept", "application/*")
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return fmt.Errorf("properties request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("properties write failed: HTTP %d - %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
 // objectTypeToURI maps an object type and name to the ADT URI path
 func objectTypeToURI(objectType, objectName string) (string, error) {
 	name := strings.ToLower(objectName)
@@ -2609,6 +2880,10 @@ func objectTypeToURI(objectType, objectName string) (string, error) {
 		return fmt.Sprintf("/sap/bc/adt/ddic/tables/%s", name), nil
 	case "STRU", "STRUCTURE":
 		return fmt.Sprintf("/sap/bc/adt/ddic/structures/%s", name), nil
+	case "DOMA", "DOMAIN":
+		return fmt.Sprintf("/sap/bc/adt/ddic/domains/%s", name), nil
+	case "DTEL", "DATA_ELEMENT":
+		return fmt.Sprintf("/sap/bc/adt/ddic/dataelements/%s", name), nil
 	default:
 		return "", fmt.Errorf("unsupported object type for activation: %s", objectType)
 	}

--- a/rest/models/api.go
+++ b/rest/models/api.go
@@ -1,5 +1,7 @@
 package models
 
+import "github.com/bluefunda/abaper/types"
+
 // REST API request and response structures
 
 // APIRequest represents a generic API request
@@ -17,6 +19,10 @@ type APIRequest struct {
 	Args        []string          `json:"args,omitempty"`
 	Prompt      string            `json:"prompt,omitempty"`
 	Config      map[string]string `json:"config,omitempty"`
+
+	// Structured properties for DDIC objects that are not source-text based.
+	DomainProperties      *types.DomainProperties      `json:"domain_properties,omitempty"`
+	DataElementProperties *types.DataElementProperties `json:"data_element_properties,omitempty"`
 }
 
 // APIResponse is the standard response envelope. T is the data payload type.

--- a/rest/server/fake_adt_client_test.go
+++ b/rest/server/fake_adt_client_test.go
@@ -28,6 +28,10 @@ type fakeADTClient struct {
 	createClassFn        func(ctx context.Context, name, description, packageName, source string) error
 	createFunctionFn     func(ctx context.Context, name, functionGroup, description, source string) error
 	createDDLSFn         func(ctx context.Context, name, description, source string) error
+	createDomainFn       func(ctx context.Context, name string, props types.DomainProperties) error
+	updateDomainFn       func(ctx context.Context, name string, props types.DomainProperties) error
+	createDataElementFn  func(ctx context.Context, name string, props types.DataElementProperties) error
+	updateDataElementFn  func(ctx context.Context, name string, props types.DataElementProperties) error
 	getTypeInfoFn        func(ctx context.Context, typeName string) (*types.ADTTypeInfo, error)
 	activateObjectFn     func(ctx context.Context, objectType, objectName string) (*types.ActivationResult, error)
 	runUnitTestsFn       func(ctx context.Context, objectType, objectName string) (*types.UnitTestResult, error)
@@ -160,6 +164,30 @@ func (f *fakeADTClient) UpdateStructure(ctx context.Context, name, source string
 func (f *fakeADTClient) UpdateDDLS(ctx context.Context, name, source string) error {
 	if f.updateDDLSFn != nil {
 		return f.updateDDLSFn(ctx, name, source)
+	}
+	return nil
+}
+func (f *fakeADTClient) CreateDomain(ctx context.Context, name string, props types.DomainProperties) error {
+	if f.createDomainFn != nil {
+		return f.createDomainFn(ctx, name, props)
+	}
+	return nil
+}
+func (f *fakeADTClient) UpdateDomain(ctx context.Context, name string, props types.DomainProperties) error {
+	if f.updateDomainFn != nil {
+		return f.updateDomainFn(ctx, name, props)
+	}
+	return nil
+}
+func (f *fakeADTClient) CreateDataElement(ctx context.Context, name string, props types.DataElementProperties) error {
+	if f.createDataElementFn != nil {
+		return f.createDataElementFn(ctx, name, props)
+	}
+	return nil
+}
+func (f *fakeADTClient) UpdateDataElement(ctx context.Context, name string, props types.DataElementProperties) error {
+	if f.updateDataElementFn != nil {
+		return f.updateDataElementFn(ctx, name, props)
 	}
 	return nil
 }

--- a/rest/server/server.go
+++ b/rest/server/server.go
@@ -388,6 +388,26 @@ func (rs *RestServer) createObjectHandler(w http.ResponseWriter, r *http.Request
 		err = c.CreateFunction(ctx, objectName, strings.ToUpper(req.Args[0]), description, sourceCode)
 	case "DDLS", "DATA_DEFINITION":
 		err = c.CreateDDLS(ctx, objectName, description, sourceCode)
+	case "DOMAIN", "DOMA":
+		if req.DomainProperties == nil {
+			rs.sendError(w, "domain_properties is required to create a domain", http.StatusBadRequest)
+			return
+		}
+		props := *req.DomainProperties
+		if props.Description == "" {
+			props.Description = description
+		}
+		err = c.CreateDomain(ctx, objectName, props)
+	case "DATA_ELEMENT", "DTEL":
+		if req.DataElementProperties == nil {
+			rs.sendError(w, "data_element_properties is required to create a data element", http.StatusBadRequest)
+			return
+		}
+		props := *req.DataElementProperties
+		if props.Description == "" {
+			props.Description = description
+		}
+		err = c.CreateDataElement(ctx, objectName, props)
 	default:
 		rs.sendError(w, "unsupported object type for creation: "+objectType, http.StatusBadRequest)
 		return
@@ -568,8 +588,8 @@ func (rs *RestServer) saveObjectHandler(w http.ResponseWriter, r *http.Request) 
 		rs.sendError(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
-	if req.ObjectType == "" || req.ObjectName == "" || req.Source == "" {
-		rs.sendError(w, "object_type, object_name, and source are required", http.StatusBadRequest)
+	if req.ObjectType == "" || req.ObjectName == "" {
+		rs.sendError(w, "object_type and object_name are required", http.StatusBadRequest)
 		return
 	}
 	c, err := rs.clientForRequest(r)
@@ -580,6 +600,38 @@ func (rs *RestServer) saveObjectHandler(w http.ResponseWriter, r *http.Request) 
 	objectType := strings.ToUpper(req.ObjectType)
 	objectName := strings.ToUpper(req.ObjectName)
 	ctx := r.Context()
+
+	// DDIC property objects (domain, data element) are updated via structured
+	// properties, not source text — handle them before the source requirement.
+	switch objectType {
+	case "DOMAIN", "DOMA":
+		if req.DomainProperties == nil {
+			rs.sendError(w, "domain_properties is required to update a domain", http.StatusBadRequest)
+			return
+		}
+		if err := c.UpdateDomain(ctx, objectName, *req.DomainProperties); err != nil {
+			rs.sendError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rs.sendSuccess(w, map[string]any{"object_name": objectName, "object_type": objectType, "message": fmt.Sprintf("%s %s saved successfully", objectType, objectName)})
+		return
+	case "DATA_ELEMENT", "DTEL":
+		if req.DataElementProperties == nil {
+			rs.sendError(w, "data_element_properties is required to update a data element", http.StatusBadRequest)
+			return
+		}
+		if err := c.UpdateDataElement(ctx, objectName, *req.DataElementProperties); err != nil {
+			rs.sendError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rs.sendSuccess(w, map[string]any{"object_name": objectName, "object_type": objectType, "message": fmt.Sprintf("%s %s saved successfully", objectType, objectName)})
+		return
+	}
+
+	if req.Source == "" {
+		rs.sendError(w, "source is required", http.StatusBadRequest)
+		return
+	}
 	switch objectType {
 	case "PROGRAM", "PROG":
 		err = c.UpdateProgram(ctx, objectName, req.Source)

--- a/types/adt.go
+++ b/types/adt.go
@@ -223,6 +223,44 @@ type PackageContentsResult struct {
 	ObjectTypes []PackageObjectType `json:"objectTypes"`
 }
 
+// DomainProperties describes a DDIC domain (DOMA/DD). Unlike source-text
+// objects, domains are defined by structured properties, not ABAP source.
+type DomainProperties struct {
+	Description    string `json:"description,omitempty"`
+	DataType       string `json:"data_type"`               // CHAR, NUMC, DEC, INT4, ...
+	Length         int    `json:"length"`                  // internal length
+	Decimals       int    `json:"decimals,omitempty"`      // for DEC/QUAN/CURR
+	OutputLength   int    `json:"output_length,omitempty"` // defaults to Length when 0
+	ConversionExit string `json:"conversion_exit,omitempty"`
+	LowerCase      bool   `json:"lowercase,omitempty"`
+}
+
+// DataElementProperties describes a DDIC data element (DTEL/DE). A data element
+// is either domain-based (set DomainName) or built on a predefined ABAP type
+// (set DataType/Length/Decimals).
+type DataElementProperties struct {
+	Description  string `json:"description,omitempty"`
+	DomainName   string `json:"domain_name,omitempty"` // typeKind=domain when set
+	DataType     string `json:"data_type,omitempty"`   // typeKind=predefinedAbapType otherwise
+	Length       int    `json:"length,omitempty"`
+	Decimals     int    `json:"decimals,omitempty"`
+	ShortLabel   string `json:"short_label,omitempty"`
+	MediumLabel  string `json:"medium_label,omitempty"`
+	LongLabel    string `json:"long_label,omitempty"`
+	HeadingLabel string `json:"heading_label,omitempty"`
+}
+
+// DDICPropertyWriter creates and updates DDIC objects that are defined by
+// structured properties rather than ABAP source text (domains, data elements).
+// These follow a distinct create-shell -> lock -> set-properties -> unlock ->
+// activate flow (activation must follow unlock, unlike source-text objects).
+type DDICPropertyWriter interface {
+	CreateDomain(ctx context.Context, name string, props DomainProperties) error
+	UpdateDomain(ctx context.Context, name string, props DomainProperties) error
+	CreateDataElement(ctx context.Context, name string, props DataElementProperties) error
+	UpdateDataElement(ctx context.Context, name string, props DataElementProperties) error
+}
+
 // PackageBrowser searches and navigates package contents.
 type PackageBrowser interface {
 	SearchObjects(ctx context.Context, pattern string, objectTypes []string) (*ADTSearchResult, error)
@@ -260,6 +298,7 @@ type ADTClient interface {
 	SessionManager
 	SourceReader
 	SourceWriter
+	DDICPropertyWriter
 	PackageBrowser
 	ObjectActivator
 	LangFeatures


### PR DESCRIPTION
## Summary

- Adds `CreateDomain` / `UpdateDomain` and `CreateDataElement` / `UpdateDataElement` to the `ADTClient` interface and `ADTClientImpl`.
- DDIC property objects (domains, data elements) don't have a `/source/main`; they're defined by structured XML. The flow is: create-shell POST → lock → PUT properties → unlock → activate. Activation must happen **after** unlock — SAP rejects activation of a locked DDIC property object.
- REST `POST /objects` and `PUT /objects/:name/save` wired for `DOMAIN`/`DOMA` and `DATA_ELEMENT`/`DTEL` types, accepting `domain_properties` / `data_element_properties` JSON fields.
- `DOMA` and `DTEL` added to `objectTypeToURI` so `ActivateObject` can reach them.

## Type

- [x] feature

## Customer Impact

DDIC domains and data elements can now be created and updated programmatically through the REST API. Previously these required manual SE11 / ADT work.

## Metrics

N/A — new capability, no existing baseline.

## Marketing Notes

Full DDIC parity for the two most common dictionary base types (domain, data element). Pairs with the table/structure/CDS CRUD already shipped in #100.

## Test Plan

- [x] Live-verified via raw curl: create-shell → lock → PUT properties → unlock → activate works end-to-end for both a domain (`ZABPB_DOM1`, CHAR 10) and a data element referencing it (`ZABPB_DTEL1`), both reaching `version="active"`.
- [ ] **Blocker (why draft):** Go path activation leaves objects `version="new"`. `ActivateObject` returns `activated:true` but SAP produces an empty worklist — suspected cause is the `ActivationRequest` XML using un-prefixed `objectReferences`/`objectReference`/`uri`/`name` with a default namespace, while the proven curl uses `adtcore:`-prefixed elements. Source-text objects activate fine with the current shape; fix needed specifically for DDIC property types.
- [ ] Once activation is fixed: verify `version="active"` through the Go path for both domain and data element.
- [ ] REST endpoint smoke tests for create and save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)