### PR TITLE
fix(adt): use adtcore:-prefixed XML for DDIC property object activation

### DIFF
--- a/internal/adt/client.go
+++ b/internal/adt/client.go
@@ -2830,10 +2830,44 @@ func (c *ADTClientImpl) setPropertiesAndActivate(ctx context.Context, objectType
 	if err := c.unlockObject(ctx, objectPath, lockHandle); err != nil {
 		return fmt.Errorf("failed to unlock %s: %w", name, err)
 	}
-	if _, err := c.ActivateObject(ctx, objectType, name); err != nil {
+	if err := c.activateDDICPropertyObject(ctx, objectPath, name); err != nil {
 		return fmt.Errorf("failed to activate %s: %w", name, err)
 	}
 	c.logger.Info("DDIC property object saved and activated", zap.String("type", objectType), zap.String("name", name))
+	return nil
+}
+
+// activateDDICPropertyObject sends the adtcore:-prefixed activation XML that SAP
+// requires for DDIC property objects (domains, data elements). The generic
+// ActivateObject emits a default-namespace form that produces an empty worklist
+// for these types, so they never reach version="active".
+func (c *ADTClientImpl) activateDDICPropertyObject(ctx context.Context, objectPath, name string) error {
+	adtURI := fmt.Sprintf("/sap/bc/adt%s", objectPath)
+	payload := fmt.Sprintf(
+		`<?xml version="1.0" encoding="UTF-8"?>`+"\n"+
+			`<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">`+
+			`<adtcore:objectReference adtcore:uri="%s" adtcore:name="%s"/>`+
+			`</adtcore:objectReferences>`,
+		adtURI, strings.ToUpper(name),
+	)
+	activateURL := c.baseURL + "/activation?method=activate&preauditRequested=true&sap-client=" + c.config.Client + "&sap-language=" + c.config.Language
+	req, err := http.NewRequestWithContext(ctx, "POST", activateURL, strings.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create activation request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	req.Header.Set("Content-Type", "application/*")
+	req.Header.Set("Accept", "application/*")
+	req.Header.Set("X-CSRF-Token", c.csrfToken)
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return fmt.Errorf("activation request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("activation failed: HTTP %d - %s", resp.StatusCode, string(body))
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- `ActivateObject` marshals `<objectReferences xmlns="http://www.sap.com/adt/core">` (default namespace). SAP accepts this for source-text objects but produces an **empty activation worklist** for DDIC property objects, leaving them `version="new"`.
- The live-proven curl shape is `<adtcore:objectReferences xmlns:adtcore="...">` with `adtcore:`-prefixed child elements and attributes.
- Adds `activateDDICPropertyObject` that builds the correct raw XML string and wires it into `setPropertiesAndActivate` (used by `UpdateDomain` and `UpdateDataElement`) in place of `ActivateObject`.

Closes the open item from #102.

## Type

- [x] fix

## Customer Impact

Domains and data elements created/updated via the Go path now reach `version="active"` instead of being left inactive.

## Metrics

N/A

## Marketing Notes

N/A

## Test Plan

- [ ] `CreateDomain` end-to-end: verify object reaches `version="active"` on SAP
- [ ] `UpdateDomain` end-to-end: verify re-activation after property change
- [ ] `CreateDataElement` (domain-referenced): verify `version="active"`
- [ ] `CreateDataElement` (predefined type): verify `version="active"`
- [ ] Existing source-text object activation unchanged (programs, classes, CDS views)

🤖 Generated with [Claude Code](https://claude.com/claude-code)