### PR TITLE
feat(adt): OData V4 (RAP) service exposure — Service Definition + Service Binding

### DIFF
--- a/internal/adt/activation_checklist_test.go
+++ b/internal/adt/activation_checklist_test.go
@@ -1,0 +1,74 @@
+package adt
+
+import "testing"
+
+// These fixtures are the literal chkl:messages bodies SAP returned (HTTP 200
+// in both cases) when live-testing activation of a Service Definition
+// referencing an inactive CDS view — the bug that motivated this parsing:
+// a 200 status alone does not mean the object activated.
+const activationChecklistErrorBody = `<?xml version="1.0" encoding="utf-8"?><chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklist"><chkl:properties checkExecuted="true" activationExecuted="false" generationExecuted="false"/><msg objDescr="" type="W" line="0" href=""><shortText><txt>Activation was cancelled.</txt><txt>"Editing canceled" (EU 202)</txt></shortText></msg><msg objDescr="Service Definition ZODT_TESTSRV" type="E" line="1" href="/sap/bc/adt/ddic/srvd/sources/zodt_testsrv/source/main#start=3,9;end=3,22"><shortText><txt>Entity 'ZODT_TESTVIEW' does not exist</txt></shortText></msg></chkl:messages>`
+
+const activationChecklistSuccessBody = `<?xml version="1.0" encoding="utf-8"?><chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklist"><chkl:properties checkExecuted="true" activationExecuted="true" generationExecuted="true"/></chkl:messages>`
+
+// activationChecklistNotExecutedBody is the literal body SAP returned live
+// when activation was attempted immediately after unlocking a just-created
+// object: no messages at all, just checkExecuted="false". This is the real
+// root cause behind CreateSRVD/CreateDDLS reporting "activated: true" while
+// SAP actually left the object inactive — it must not be read as success.
+const activationChecklistNotExecutedBody = `<?xml version="1.0" encoding="utf-8"?><chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklist"><chkl:properties checkExecuted="false" activationExecuted="false" generationExecuted="false"/></chkl:messages>`
+
+func TestActivationChecklistOutcomeDistinguishesNotExecuted(t *testing.T) {
+	checked, errText := activationChecklistOutcome([]byte(activationChecklistNotExecutedBody))
+	if checked {
+		t.Error("expected checkExecuted=false to be reported as not executed")
+	}
+	if errText != "" {
+		t.Errorf("expected no error text when the check never ran, got: %q", errText)
+	}
+	// activationChecklistError alone (no outcome distinction) must not treat
+	// this as a clean pass either, since it reports the same "no error text"
+	// as a genuine success — this is exactly why callers use
+	// activationChecklistOutcome/activate*WithRetry instead of trusting a nil
+	// activationChecklistError as "activated".
+	if err := activationChecklistError([]byte(activationChecklistNotExecutedBody)); err != nil {
+		t.Errorf("activationChecklistError should not itself error on this body, got: %v", err)
+	}
+}
+
+func TestActivationChecklistOutcomeDetectsSuccess(t *testing.T) {
+	checked, errText := activationChecklistOutcome([]byte(activationChecklistSuccessBody))
+	if !checked {
+		t.Error("expected checkExecuted=true to be reported as executed")
+	}
+	if errText != "" {
+		t.Errorf("expected no error text for a genuine success, got: %q", errText)
+	}
+}
+
+func TestActivationChecklistErrorDetectsFailure(t *testing.T) {
+	err := activationChecklistError([]byte(activationChecklistErrorBody))
+	if err == nil {
+		t.Fatal("expected an error for a checklist body containing a type=\"E\" message, got nil")
+	}
+	if got := err.Error(); got != "Entity 'ZODT_TESTVIEW' does not exist" {
+		t.Errorf("expected the error-severity message text only (warnings excluded), got: %q", got)
+	}
+}
+
+func TestActivationChecklistErrorAllowsSuccess(t *testing.T) {
+	if err := activationChecklistError([]byte(activationChecklistSuccessBody)); err != nil {
+		t.Errorf("expected no error for a checklist body with no error messages, got: %v", err)
+	}
+}
+
+func TestIsActivationError(t *testing.T) {
+	cases := map[string]bool{
+		"E": true, "A": true, "error": true,
+		"W": false, "S": false, "": false,
+	}
+	for severity, want := range cases {
+		if got := isActivationError(severity); got != want {
+			t.Errorf("isActivationError(%q) = %v, want %v", severity, got, want)
+		}
+	}
+}

--- a/internal/adt/client.go
+++ b/internal/adt/client.go
@@ -21,29 +21,30 @@ import (
 
 // ADT Endpoint Constants
 const (
-	nodestructureEndpoint   = "/repository/nodestructure"
-	programsEndpoint        = "/programs/programs/%s/source/main"
-	classesEndpoint         = "/oo/classes/%s/source/main"
-	functionGroupsEndpoint  = "/functions/groups/%s/source/main"
-	functionsEndpoint       = "/functions/groups/%s/fmodules/%s/source/main"
-	tablesEndpoint          = "/ddic/tables/%s/source/main"
-	structuresEndpoint      = "/ddic/structures/%s/source/main"
-	includesEndpoint        = "/programs/includes/%s/source/main"
-	interfacesEndpoint      = "/oo/interfaces/%s/source/main"
-	domainsEndpoint         = "/ddic/domains/%s"
-	dataElementsEndpoint    = "/ddic/dataelements/%s"
-	ddlSourcesEndpoint      = "/ddic/ddl/sources/%s/source/main"
-	searchEndpoint = "/repository/informationsystem/search"
-	transactionEndpoint     = "/repository/informationsystem/objectproperties/values"
-	programsCreateEndpoint  = "/programs/programs"
-	classesCreateEndpoint   = "/oo/classes"
-	tableContentsEndpoint      = "/z_mcp_abap_adt/z_tablecontent/%s" // Custom service required
-	formatEndpoint             = "/abapsource/prettyprinter"
-	transportInfoSuffix        = "/transportinfo"
-	createTransportSuffix      = "/transports"
-	interfacesCreateEndpoint   = "/oo/interfaces"
+	nodestructureEndpoint        = "/repository/nodestructure"
+	programsEndpoint             = "/programs/programs/%s/source/main"
+	classesEndpoint              = "/oo/classes/%s/source/main"
+	functionGroupsEndpoint       = "/functions/groups/%s/source/main"
+	functionsEndpoint            = "/functions/groups/%s/fmodules/%s/source/main"
+	tablesEndpoint               = "/ddic/tables/%s/source/main"
+	structuresEndpoint           = "/ddic/structures/%s/source/main"
+	includesEndpoint             = "/programs/includes/%s/source/main"
+	interfacesEndpoint           = "/oo/interfaces/%s/source/main"
+	domainsEndpoint              = "/ddic/domains/%s"
+	dataElementsEndpoint         = "/ddic/dataelements/%s"
+	ddlSourcesEndpoint           = "/ddic/ddl/sources/%s/source/main"
+	srvdSourcesEndpoint          = "/ddic/srvd/sources/%s/source/main"
+	searchEndpoint               = "/repository/informationsystem/search"
+	transactionEndpoint          = "/repository/informationsystem/objectproperties/values"
+	programsCreateEndpoint       = "/programs/programs"
+	classesCreateEndpoint        = "/oo/classes"
+	tableContentsEndpoint        = "/z_mcp_abap_adt/z_tablecontent/%s" // Custom service required
+	formatEndpoint               = "/abapsource/prettyprinter"
+	transportInfoSuffix          = "/transportinfo"
+	createTransportSuffix        = "/transports"
+	interfacesCreateEndpoint     = "/oo/interfaces"
 	functionGroupsCreateEndpoint = "/functions/groups"
-	includesCreateEndpoint     = "/programs/includes"
+	includesCreateEndpoint       = "/programs/includes"
 )
 
 // ErrNotFound is returned when an ADT object does not exist (HTTP 404).
@@ -358,6 +359,11 @@ func (c *ADTClientImpl) GetFunctionGroup(ctx context.Context, functionGroup stri
 // GetDDLSource retrieves CDS / DDL source code.
 func (c *ADTClientImpl) GetDDLSource(ctx context.Context, name string) (*types.ADTSourceCode, error) {
 	return c.getSource(ctx, "DDLS", name, ddlSourcesEndpoint)
+}
+
+// GetSRVDSource retrieves Service Definition (SRVD/SRV) source code.
+func (c *ADTClientImpl) GetSRVDSource(ctx context.Context, name string) (*types.ADTSourceCode, error) {
+	return c.getSource(ctx, "SRVD", name, srvdSourcesEndpoint)
 }
 
 // GetInclude retrieves ABAP include source code.
@@ -976,14 +982,14 @@ func (c *ADTClientImpl) CreateClassWithOptions(ctx context.Context, opts CreateC
 
 // classCreatePayload is the XML struct for class creation.
 type classCreatePayload struct {
-	XMLName     xml.Name           `xml:"class:abapClass"`
-	ClassNS     string             `xml:"xmlns:class,attr"`
-	AdtcoreNS   string             `xml:"xmlns:adtcore,attr"`
-	Description string             `xml:"adtcore:description,attr"`
-	Name        string             `xml:"adtcore:name,attr"`
-	Type        string             `xml:"adtcore:type,attr"`
-	Responsible string             `xml:"adtcore:responsible,attr"`
-	PackageRef  classPackageRef    `xml:"adtcore:packageRef"`
+	XMLName     xml.Name        `xml:"class:abapClass"`
+	ClassNS     string          `xml:"xmlns:class,attr"`
+	AdtcoreNS   string          `xml:"xmlns:adtcore,attr"`
+	Description string          `xml:"adtcore:description,attr"`
+	Name        string          `xml:"adtcore:name,attr"`
+	Type        string          `xml:"adtcore:type,attr"`
+	Responsible string          `xml:"adtcore:responsible,attr"`
+	PackageRef  classPackageRef `xml:"adtcore:packageRef"`
 }
 
 type classPackageRef struct {
@@ -1072,16 +1078,14 @@ func (c *ADTClientImpl) activateClass(ctx context.Context, opts *CreateClassOpti
 	}
 	defer resp.Body.Close()
 
+	responseBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("activation failed: HTTP %d - %s", resp.StatusCode, string(body))
+		return fmt.Errorf("activation failed: HTTP %d - %s", resp.StatusCode, string(responseBody))
 	}
-
-	// Parse activation response to check for warnings/errors
-	responseBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		c.logger.Warn("Could not read activation response", zap.Error(err))
-		return nil // Don't fail if we can't read the response
+	// SAP answers HTTP 200 for this endpoint even when activation itself
+	// failed, so the checklist messages must be checked too.
+	if actErr := activationChecklistError(responseBody); actErr != nil {
+		return fmt.Errorf("activation of class %s failed: %w", opts.Name, actErr)
 	}
 
 	c.logger.Debug("Activation response", zap.String("class", opts.Name), zap.String("body", string(responseBody)))
@@ -1124,58 +1128,34 @@ func (c *ADTClientImpl) createAndPopulate(ctx context.Context, createEndpoint, o
 		if err != nil {
 			return fmt.Errorf("failed to lock: %w", err)
 		}
-		defer func() {
-			if unlockErr := c.unlockObject(ctx, objectPath, lockHandle); unlockErr != nil {
-				c.logger.Warn("Failed to unlock", zap.String("path", objectPath), zap.Error(unlockErr))
-			}
-		}()
-		if err := c.setObjectSource(ctx, sourcePath, source, lockHandle, corrNr); err != nil {
-			return fmt.Errorf("failed to write source: %w", err)
+		setErr := c.setObjectSource(ctx, sourcePath, source, lockHandle, corrNr)
+		// Unlock before activating, not deferred to function return: confirmed
+		// live that SAP silently no-ops activation on a still-locked object
+		// (checklist comes back with checkExecuted="false" and no messages at
+		// all, indistinguishable from success) rather than erroring.
+		if unlockErr := c.unlockObject(ctx, objectPath, lockHandle); unlockErr != nil {
+			c.logger.Warn("Failed to unlock", zap.String("path", objectPath), zap.Error(unlockErr))
+		}
+		if setErr != nil {
+			return fmt.Errorf("failed to write source: %w", setErr)
 		}
 	}
 	if !activate {
 		return nil
 	}
 	uri := fmt.Sprintf("/sap/bc/adt%s", objectPath)
-	activationReq := ActivationRequest{
-		Namespace: "http://www.sap.com/adt/core",
-		ObjectRef: ActivationRef{URI: uri, Name: strings.ToUpper(name)},
-	}
-	xmlPayload, err := xml.Marshal(activationReq)
-	if err != nil {
-		return fmt.Errorf("marshal activation: %w", err)
-	}
-	fullPayload := `<?xml version="1.0" encoding="UTF-8"?>` + "\n" + string(xmlPayload)
-	activateURL := c.baseURL + "/activation?method=activate&preauditRequested=true&sap-client=" + c.config.Client + "&sap-language=" + c.config.Language
-	req, err := http.NewRequestWithContext(ctx, "POST", activateURL, strings.NewReader(fullPayload))
-	if err != nil {
-		return fmt.Errorf("failed to create activation request: %w", err)
-	}
-	c.addAuthHeaders(req)
-	req.Header.Set("Content-Type", "application/*")
-	req.Header.Set("Accept", "application/*")
-	req.Header.Set("X-CSRF-Token", c.csrfToken)
-	resp, err := c.doRequest(req)
-	if err != nil {
-		return fmt.Errorf("activation request failed: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("activation failed: HTTP %d - %s", resp.StatusCode, string(body))
-	}
-	return nil
+	return c.activateWithRetry(ctx, uri, name)
 }
 
 type interfaceCreatePayload struct {
-	XMLName     xml.Name         `xml:"intf:abapInterface"`
-	IntfNS      string           `xml:"xmlns:intf,attr"`
-	AdtcoreNS   string           `xml:"xmlns:adtcore,attr"`
-	Description string           `xml:"adtcore:description,attr"`
-	Name        string           `xml:"adtcore:name,attr"`
-	Type        string           `xml:"adtcore:type,attr"`
-	Responsible string           `xml:"adtcore:responsible,attr"`
-	PackageRef  classPackageRef  `xml:"adtcore:packageRef"`
+	XMLName     xml.Name        `xml:"intf:abapInterface"`
+	IntfNS      string          `xml:"xmlns:intf,attr"`
+	AdtcoreNS   string          `xml:"xmlns:adtcore,attr"`
+	Description string          `xml:"adtcore:description,attr"`
+	Name        string          `xml:"adtcore:name,attr"`
+	Type        string          `xml:"adtcore:type,attr"`
+	Responsible string          `xml:"adtcore:responsible,attr"`
+	PackageRef  classPackageRef `xml:"adtcore:packageRef"`
 }
 
 func (c *ADTClientImpl) CreateInterface(ctx context.Context, name, description, source string) error {
@@ -1666,16 +1646,26 @@ type ObjectRef struct {
 	Name       string `xml:"name,attr"`
 }
 
-// ActivationRequest represents the activation request structure
+// ActivationRequest represents the activation request structure.
+//
+// Confirmed live against abap.bluefunda.com and cross-checked against the
+// abap-adt-api reference (github.com/marcellourbani/abap-adt-api,
+// src/api/activate.ts, always emits adtcore:objectReferences): the
+// default/unprefixed namespace form this struct used to emit
+// (<objectReferences xmlns="...">) makes SAP's activation checklist come
+// back with checkExecuted="false" and zero messages — indistinguishable
+// from success, but the object stays inactive — no matter how long you
+// retry. The adtcore:-prefixed form below is the one every other ADT client
+// uses and the one that actually runs the check.
 type ActivationRequest struct {
-	XMLName   xml.Name      `xml:"objectReferences"`
-	Namespace string        `xml:"xmlns,attr"`
-	ObjectRef ActivationRef `xml:"objectReference"`
+	XMLName   xml.Name      `xml:"adtcore:objectReferences"`
+	Namespace string        `xml:"xmlns:adtcore,attr"`
+	ObjectRef ActivationRef `xml:"adtcore:objectReference"`
 }
 
 type ActivationRef struct {
-	URI  string `xml:"uri,attr"`
-	Name string `xml:"name,attr"`
+	URI  string `xml:"adtcore:uri,attr"`
+	Name string `xml:"adtcore:name,attr"`
 }
 
 // CreateProgram creates a new ABAP program - now with working atomic approach
@@ -1759,14 +1749,14 @@ func (c *ADTClientImpl) parseLockResponse(responseBody []byte) (lockHandle, corr
 
 // programCreatePayload is the XML struct for program creation.
 type programCreatePayload struct {
-	XMLName     xml.Name           `xml:"program:abapProgram"`
-	ProgramNS   string             `xml:"xmlns:program,attr"`
-	AdtcoreNS   string             `xml:"xmlns:adtcore,attr"`
-	Description string             `xml:"adtcore:description,attr"`
-	Name        string             `xml:"adtcore:name,attr"`
-	Type        string             `xml:"adtcore:type,attr"`
-	Responsible string             `xml:"adtcore:responsible,attr"`
-	PackageRef  programPackageRef  `xml:"adtcore:packageRef"`
+	XMLName     xml.Name          `xml:"program:abapProgram"`
+	ProgramNS   string            `xml:"xmlns:program,attr"`
+	AdtcoreNS   string            `xml:"xmlns:adtcore,attr"`
+	Description string            `xml:"adtcore:description,attr"`
+	Name        string            `xml:"adtcore:name,attr"`
+	Type        string            `xml:"adtcore:type,attr"`
+	Responsible string            `xml:"adtcore:responsible,attr"`
+	PackageRef  programPackageRef `xml:"adtcore:packageRef"`
 }
 
 type programPackageRef struct {
@@ -2127,16 +2117,14 @@ func (c *ADTClientImpl) activateProgram(ctx context.Context, opts *CreateProgram
 	}
 	defer resp.Body.Close()
 
+	responseBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("activation failed: HTTP %d - %s", resp.StatusCode, string(body))
+		return fmt.Errorf("activation failed: HTTP %d - %s", resp.StatusCode, string(responseBody))
 	}
-
-	// Parse activation response to check for warnings/errors
-	responseBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		c.logger.Warn("Could not read activation response", zap.Error(err))
-		return nil // Don't fail if we can't read the response
+	// SAP answers HTTP 200 for this endpoint even when activation itself
+	// failed, so the checklist messages must be checked too.
+	if actErr := activationChecklistError(responseBody); actErr != nil {
+		return fmt.Errorf("activation of program %s failed: %w", opts.Name, actErr)
 	}
 
 	// Log activation response for debugging
@@ -2267,7 +2255,6 @@ func (c *ADTClientImpl) UpdateProgram(ctx context.Context, name, source string) 
 	c.logger.Info("Program updated successfully", zap.String("name", name))
 	return nil
 }
-
 
 // UpdateClass updates an existing ABAP class's source code
 func (c *ADTClientImpl) UpdateClass(ctx context.Context, name, source string) error {
@@ -2589,6 +2576,62 @@ func (c *ADTClientImpl) UpdateDDLS(ctx context.Context, name, source string) err
 	return c.updateSourceObject(ctx, "CDS view", objectPath, objectPath+"/source/main", name, source)
 }
 
+// srvdSourceCreatePayload is the create-shell body for a Service Definition
+// (SRVD/SRV). srvd:srvdSourceType="S" (Definition, vs. "X" Extension) is
+// required — confirmed live: SAP rejects creation with "Service Definition
+// type ” does not exist" if this attribute is omitted.
+type srvdSourceCreatePayload struct {
+	XMLName        xml.Name        `xml:"srvd:srvdSource"`
+	SrvdNS         string          `xml:"xmlns:srvd,attr"`
+	AdtcoreNS      string          `xml:"xmlns:adtcore,attr"`
+	Description    string          `xml:"adtcore:description,attr"`
+	Name           string          `xml:"adtcore:name,attr"`
+	Type           string          `xml:"adtcore:type,attr"`
+	Language       string          `xml:"adtcore:language,attr"`
+	MasterLanguage string          `xml:"adtcore:masterLanguage,attr"`
+	Responsible    string          `xml:"adtcore:responsible,attr"`
+	SourceType     string          `xml:"srvd:srvdSourceType,attr"`
+	PackageRef     classPackageRef `xml:"adtcore:packageRef"`
+}
+
+// CreateSRVD creates a new Service Definition (SRVD/SRV), which exposes one
+// or more CDS views for OData consumption via a Service Binding.
+func (c *ADTClientImpl) CreateSRVD(ctx context.Context, name, description, source string) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	payload := srvdSourceCreatePayload{
+		SrvdNS:         "http://www.sap.com/adt/ddic/srvdsources",
+		AdtcoreNS:      "http://www.sap.com/adt/core",
+		Description:    description,
+		Name:           name,
+		Type:           "SRVD/SRV",
+		Language:       "EN",
+		MasterLanguage: "EN",
+		Responsible:    strings.ToUpper(strings.TrimSpace(c.config.Username)),
+		SourceType:     "S",
+		PackageRef:     classPackageRef{Name: "$TMP"},
+	}
+	xmlBytes, err := xml.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal service definition metadata: %w", err)
+	}
+	if err := c.createObjectMetadata(ctx, "/ddic/srvd/sources", xml.Header+string(xmlBytes)); err != nil {
+		return fmt.Errorf("create service definition %s: %w", name, err)
+	}
+	nameLower := strings.ToLower(name)
+	return c.createAndPopulate(ctx, "/ddic/srvd/sources",
+		"/ddic/srvd/sources/"+nameLower,
+		"/ddic/srvd/sources/"+nameLower+"/source/main",
+		"SRVD", name, source, source != "")
+}
+
+// UpdateSRVD updates an existing Service Definition's (SRVD/SRV) source.
+func (c *ADTClientImpl) UpdateSRVD(ctx context.Context, name, source string) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	nameLower := strings.ToLower(name)
+	objectPath := fmt.Sprintf("/ddic/srvd/sources/%s", nameLower)
+	return c.updateSourceObject(ctx, "service definition", objectPath, objectPath+"/source/main", name, source)
+}
+
 // --- DDIC property objects (domains, data elements) ---
 //
 // Domains and data elements are not source-text objects: they are defined by
@@ -2768,16 +2811,16 @@ func (c *ADTClientImpl) CreateDataElement(ctx context.Context, name string, prop
 func (c *ADTClientImpl) UpdateDataElement(ctx context.Context, name string, props types.DataElementProperties) error {
 	name = strings.ToUpper(strings.TrimSpace(name))
 	inner := dataElementInner{
-		ShortLabel:   props.ShortLabel,
-		ShortLength:  10,
+		ShortLabel:       props.ShortLabel,
+		ShortLength:      10,
 		ShortMaxLength:   10,
-		MediumLabel:  props.MediumLabel,
-		MediumLength: 20,
+		MediumLabel:      props.MediumLabel,
+		MediumLength:     20,
 		MediumMaxLength:  20,
-		LongLabel:    props.LongLabel,
-		LongLength:   40,
+		LongLabel:        props.LongLabel,
+		LongLength:       40,
 		LongMaxLength:    40,
-		HeadingLabel: props.HeadingLabel,
+		HeadingLabel:     props.HeadingLabel,
 		HeadingLength:    55,
 		HeadingMaxLength: 55,
 	}
@@ -2809,6 +2852,260 @@ func (c *ADTClientImpl) UpdateDataElement(ctx context.Context, name string, prop
 		return fmt.Errorf("marshal data element properties: %w", err)
 	}
 	return c.setPropertiesAndActivate(ctx, "DATA_ELEMENT", "/ddic/dataelements/"+strings.ToLower(name), name, xml.Header+string(xmlBytes))
+}
+
+// --- Service Bindings (RAP OData exposure of CDS views) ---
+//
+// A Service Binding (SRVB/SVB) is, like domains/data elements, structured
+// metadata rather than source text. Confirmed live against SAP ADT: unlike
+// those DDIC property objects, the *create* call accepts the full binding
+// content (services + binding type) in a single POST — no separate
+// create-shell + set-properties step is needed. Update still requires the
+// lock -> PUT -> unlock -> activate cycle shared with domains/data elements.
+
+type srvbServiceRef struct {
+	Name string `xml:"adtcore:name,attr"`
+}
+
+type srvbContent struct {
+	Version           string         `xml:"srvb:version,attr"`
+	ServiceDefinition srvbServiceRef `xml:"srvb:serviceDefinition"`
+}
+
+type srvbServices struct {
+	Name    string      `xml:"srvb:name,attr"`
+	Content srvbContent `xml:"srvb:content"`
+}
+
+type srvbImplementation struct {
+	Name string `xml:"adtcore:name,attr"`
+}
+
+type srvbBinding struct {
+	Category       string             `xml:"srvb:category,attr"`
+	Type           string             `xml:"srvb:type,attr"`
+	Version        string             `xml:"srvb:version,attr"`
+	Implementation srvbImplementation `xml:"srvb:implementation"`
+}
+
+type serviceBindingPayload struct {
+	XMLName        xml.Name        `xml:"srvb:serviceBinding"`
+	SrvbNS         string          `xml:"xmlns:srvb,attr"`
+	AdtcoreNS      string          `xml:"xmlns:adtcore,attr"`
+	Description    string          `xml:"adtcore:description,attr"`
+	Name           string          `xml:"adtcore:name,attr"`
+	Type           string          `xml:"adtcore:type,attr"`
+	Language       string          `xml:"adtcore:language,attr"`
+	MasterLanguage string          `xml:"adtcore:masterLanguage,attr"`
+	Responsible    string          `xml:"adtcore:responsible,attr"`
+	PackageRef     classPackageRef `xml:"adtcore:packageRef"`
+	Services       srvbServices    `xml:"srvb:services"`
+	Binding        srvbBinding     `xml:"srvb:binding"`
+}
+
+// buildServiceBindingPayload builds the srvb:serviceBinding XML shared by
+// create and update. BindingVersion defaults to "V4" and BindingCategory
+// to "0" (UI) when unset, since this feature targets RAP V4 services.
+func (c *ADTClientImpl) buildServiceBindingPayload(name string, props types.ServiceBindingProperties) ([]byte, error) {
+	version := strings.ToUpper(strings.TrimSpace(props.BindingVersion))
+	if version == "" {
+		version = "V4"
+	}
+	category := strings.TrimSpace(props.BindingCategory)
+	if category == "" {
+		category = "0"
+	}
+	payload := serviceBindingPayload{
+		SrvbNS:         "http://www.sap.com/adt/ddic/ServiceBindings",
+		AdtcoreNS:      "http://www.sap.com/adt/core",
+		Description:    props.Description,
+		Name:           name,
+		Type:           "SRVB/SVB",
+		Language:       "EN",
+		MasterLanguage: "EN",
+		Responsible:    strings.ToUpper(strings.TrimSpace(c.config.Username)),
+		PackageRef:     classPackageRef{Name: "$TMP"},
+		Services: srvbServices{
+			Name: name,
+			Content: srvbContent{
+				Version:           "0001",
+				ServiceDefinition: srvbServiceRef{Name: strings.ToUpper(strings.TrimSpace(props.ServiceDefinitionName))},
+			},
+		},
+		Binding: srvbBinding{
+			Category:       category,
+			Type:           "ODATA",
+			Version:        version,
+			Implementation: srvbImplementation{Name: ""},
+		},
+	}
+	xmlBytes, err := xml.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal service binding: %w", err)
+	}
+	return xmlBytes, nil
+}
+
+// CreateServiceBinding creates a Service Binding (SRVB/SVB), exposing a
+// Service Definition as an OData service. The object is created inactive
+// and then activated; call PublishServiceBinding afterward to register the
+// runtime OData endpoint.
+func (c *ADTClientImpl) CreateServiceBinding(ctx context.Context, name string, props types.ServiceBindingProperties) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	xmlBytes, err := c.buildServiceBindingPayload(name, props)
+	if err != nil {
+		return err
+	}
+	if err := c.createObjectMetadata(ctx, "/businessservices/bindings", xml.Header+string(xmlBytes)); err != nil {
+		return fmt.Errorf("create service binding %s: %w", name, err)
+	}
+	// Service bindings need the same adtcore:-prefixed activation form as
+	// domains/data elements (confirmed live) — the generic default-namespace
+	// form produces an empty activation worklist for these metadata-only types.
+	if err := c.activateDDICPropertyObject(ctx, "/businessservices/bindings/"+strings.ToLower(name), name); err != nil {
+		return fmt.Errorf("failed to activate service binding %s: %w", name, err)
+	}
+	return nil
+}
+
+// UpdateServiceBinding updates an existing Service Binding's properties and activates it.
+func (c *ADTClientImpl) UpdateServiceBinding(ctx context.Context, name string, props types.ServiceBindingProperties) error {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	xmlBytes, err := c.buildServiceBindingPayload(name, props)
+	if err != nil {
+		return err
+	}
+	return c.setPropertiesAndActivate(ctx, "SERVICE_BINDING", "/businessservices/bindings/"+strings.ToLower(name), name, xml.Header+string(xmlBytes))
+}
+
+// serviceBindingReadResponse parses the srvb:serviceBinding XML returned by
+// GET. Go's xml package matches elements/attributes by local name, so the
+// srvb:/adtcore: namespace prefixes in the live response don't need to be
+// declared in these tags.
+type serviceBindingReadResponse struct {
+	XMLName     xml.Name `xml:"serviceBinding"`
+	Name        string   `xml:"name,attr"`
+	Description string   `xml:"description,attr"`
+	Version     string   `xml:"version,attr"`
+	Published   bool     `xml:"published,attr"`
+	Services    struct {
+		Content struct {
+			Version           string `xml:"version,attr"`
+			ServiceDefinition struct {
+				Name string `xml:"name,attr"`
+			} `xml:"serviceDefinition"`
+		} `xml:"content"`
+	} `xml:"services"`
+	Binding struct {
+		Category string `xml:"category,attr"`
+		Version  string `xml:"version,attr"`
+	} `xml:"binding"`
+}
+
+// GetServiceBinding retrieves a Service Binding's properties.
+func (c *ADTClientImpl) GetServiceBinding(ctx context.Context, name string) (*types.ADTServiceBinding, error) {
+	if !c.IsAuthenticated() {
+		return nil, fmt.Errorf("client not authenticated - call Authenticate() first")
+	}
+	name = strings.ToUpper(strings.TrimSpace(name))
+	reqURL := fmt.Sprintf("%s/businessservices/bindings/%s", c.baseURL, strings.ToLower(name))
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	req.Header.Set("Accept", "application/vnd.sap.adt.businessservices.servicebinding.v2+xml")
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("get service binding failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("%w: SRVB %s", ErrNotFound, name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("get service binding %s: HTTP %d - %s", name, resp.StatusCode, string(body))
+	}
+	var parsed serviceBindingReadResponse
+	if err := xml.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse service binding response: %w", err)
+	}
+	return &types.ADTServiceBinding{
+		Name:                  name,
+		Description:           parsed.Description,
+		ServiceDefinitionName: parsed.Services.Content.ServiceDefinition.Name,
+		BindingVersion:        parsed.Binding.Version,
+		BindingCategory:       parsed.Binding.Category,
+		Version:               parsed.Version,
+		Published:             parsed.Published,
+	}, nil
+}
+
+// servicePublishResponse parses the asx:abap SEVERITY/SHORT_TEXT/LONG_TEXT
+// response returned by the odatav4 publishjobs endpoint.
+type servicePublishResponse struct {
+	XMLName xml.Name `xml:"abap"`
+	Values  struct {
+		Data struct {
+			Severity  string `xml:"SEVERITY"`
+			ShortText string `xml:"SHORT_TEXT"`
+			LongText  string `xml:"LONG_TEXT"`
+		} `xml:"DATA"`
+	} `xml:"values"`
+}
+
+// PublishServiceBinding registers a Service Binding's OData V4 service at
+// runtime. Confirmed live: the binding must already be created and active
+// (see CreateServiceBinding) before this succeeds.
+func (c *ADTClientImpl) PublishServiceBinding(ctx context.Context, name string) (*types.ServiceBindingPublishResult, error) {
+	if !c.IsAuthenticated() {
+		return nil, fmt.Errorf("client not authenticated - call Authenticate() first")
+	}
+	name = strings.ToUpper(strings.TrimSpace(name))
+	payload := fmt.Sprintf(
+		`<?xml version="1.0" encoding="UTF-8"?>`+"\n"+
+			`<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">`+
+			`<adtcore:objectReference adtcore:uri="/sap/bc/adt/businessservices/bindings/%s" adtcore:type="SRVB/SVB" adtcore:name="%s"/>`+
+			`</adtcore:objectReferences>`,
+		strings.ToLower(name), name,
+	)
+	reqURL := c.baseURL + "/businessservices/odatav4/publishjobs"
+	req, err := http.NewRequestWithContext(ctx, "POST", reqURL, strings.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create publish request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	req.Header.Set("Content-Type", "application/*")
+	req.Header.Set("Accept", "application/*")
+	req.Header.Set("X-CSRF-Token", c.csrfToken)
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("publish request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read publish response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("publish service binding %s failed: HTTP %d - %s", name, resp.StatusCode, string(body))
+	}
+	var parsed servicePublishResponse
+	result := &types.ServiceBindingPublishResult{}
+	if err := xml.Unmarshal(body, &parsed); err == nil {
+		result.Severity = parsed.Values.Data.Severity
+		result.ShortText = parsed.Values.Data.ShortText
+		result.LongText = parsed.Values.Data.LongText
+	}
+	c.logger.Info("Service binding publish requested",
+		zap.String("name", name),
+		zap.String("severity", result.Severity),
+		zap.String("message", result.ShortText))
+	return result, nil
 }
 
 // setPropertiesAndActivate runs the lock -> PUT properties -> unlock -> activate
@@ -2850,25 +3147,7 @@ func (c *ADTClientImpl) activateDDICPropertyObject(ctx context.Context, objectPa
 			`</adtcore:objectReferences>`,
 		adtURI, strings.ToUpper(name),
 	)
-	activateURL := c.baseURL + "/activation?method=activate&preauditRequested=true&sap-client=" + c.config.Client + "&sap-language=" + c.config.Language
-	req, err := http.NewRequestWithContext(ctx, "POST", activateURL, strings.NewReader(payload))
-	if err != nil {
-		return fmt.Errorf("failed to create activation request: %w", err)
-	}
-	c.addAuthHeaders(req)
-	req.Header.Set("Content-Type", "application/*")
-	req.Header.Set("Accept", "application/*")
-	req.Header.Set("X-CSRF-Token", c.csrfToken)
-	resp, err := c.doRequest(req)
-	if err != nil {
-		return fmt.Errorf("activation request failed: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("activation failed: HTTP %d - %s", resp.StatusCode, string(body))
-	}
-	return nil
+	return c.activatePayloadWithRetry(ctx, payload, name)
 }
 
 // putObjectProperties PUTs a structured-properties XML body to a DDIC object URL
@@ -2918,21 +3197,163 @@ func objectTypeToURI(objectType, objectName string) (string, error) {
 		return fmt.Sprintf("/sap/bc/adt/ddic/domains/%s", name), nil
 	case "DTEL", "DATA_ELEMENT":
 		return fmt.Sprintf("/sap/bc/adt/ddic/dataelements/%s", name), nil
+	case "SRVD", "SERVICE_DEFINITION":
+		return fmt.Sprintf("/sap/bc/adt/ddic/srvd/sources/%s", name), nil
+	case "SRVB", "SERVICE_BINDING":
+		return fmt.Sprintf("/sap/bc/adt/businessservices/bindings/%s", name), nil
 	default:
 		return "", fmt.Errorf("unsupported object type for activation: %s", objectType)
 	}
 }
 
-// ActivationResponse XML structures for parsing activation results
+// ActivationResponse parses the chkl:messages checklist XML returned by the
+// ADT activation endpoint. SAP always answers HTTP 200 for this call —
+// whether activation actually succeeded is only knowable from these
+// messages: confirmed live, a "type=E" message (e.g. a syntax/reference
+// error) still comes back with HTTP 200, leaving the object inactive.
+//
+// checkExecuted="false" (with no <msg> elements at all) is a third, distinct
+// outcome confirmed live: SAP returns this when activation is attempted too
+// soon after unlocking a just-created object — the check silently never ran
+// rather than erroring, and a retry moments later succeeds. This is NOT the
+// same as a real pass (which has checkExecuted="true" and no error message)
+// and must not be treated as success.
 type ActivationResponse struct {
-	XMLName  xml.Name             `xml:"messages"`
+	XMLName    xml.Name `xml:"messages"`
+	Properties struct {
+		CheckExecuted bool `xml:"checkExecuted,attr"`
+	} `xml:"properties"`
 	Messages []ActivationMsgEntry `xml:"msg"`
 }
 
 type ActivationMsgEntry struct {
-	Severity string `xml:"severity,attr"`
-	Text     string `xml:",chardata"`
-	Href     string `xml:"href,attr,omitempty"`
+	Severity  string   `xml:"type,attr"`
+	Href      string   `xml:"href,attr,omitempty"`
+	ShortText []string `xml:"shortText>txt"`
+}
+
+// Text joins the (possibly multi-line) shortText of an activation message.
+func (m ActivationMsgEntry) Text() string {
+	return strings.TrimSpace(strings.Join(m.ShortText, " "))
+}
+
+// isActivationError reports whether an activation checklist message
+// severity indicates the object was NOT actually activated ("E"rror or
+// "A"bort, per the chkl:messages type attribute).
+func isActivationError(severity string) bool {
+	return severity == "E" || severity == "A" || severity == "error"
+}
+
+// activationChecklistOutcome parses SAP's chkl:messages checklist body from
+// POST /activation, returning whether the check actually ran and the joined
+// text of any error/abort-severity messages ("" if none). A checkExecuted
+// of false (typically with zero messages) means SAP never actually attempted
+// the check — confirmed live, this happens when activation is requested too
+// soon after unlocking a just-created object — and must not be read as success.
+func activationChecklistOutcome(body []byte) (checkExecuted bool, errText string) {
+	var resp ActivationResponse
+	if err := xml.Unmarshal(body, &resp); err != nil {
+		return false, ""
+	}
+	var texts []string
+	for _, msg := range resp.Messages {
+		if isActivationError(msg.Severity) {
+			texts = append(texts, msg.Text())
+		}
+	}
+	return resp.Properties.CheckExecuted, strings.Join(texts, "; ")
+}
+
+// activationChecklistError extracts a human-readable error from the
+// chkl:messages checklist body returned by POST /activation, or nil if it
+// contains no error-severity messages. SAP answers HTTP 200 for this
+// endpoint regardless of outcome, so this — not the status code — is what
+// determines whether the object actually activated.
+func activationChecklistError(body []byte) error {
+	_, errText := activationChecklistOutcome(body)
+	if errText == "" {
+		return nil
+	}
+	return fmt.Errorf("%s", errText)
+}
+
+// activationRetryDelays are the backoff intervals between activation
+// attempts when SAP reports checkExecuted="false" (the check silently never
+// ran). With the correct adtcore:-prefixed activation payload this succeeds
+// on the first attempt in normal operation; these retries are cheap
+// insurance against the same occasional backend settling delay SAP's own
+// businessservices/odatav4/publishjobs endpoint acknowledges via its
+// "please try publishing again later" message.
+var activationRetryDelays = []time.Duration{0, 500 * time.Millisecond, 1500 * time.Millisecond, 3 * time.Second}
+
+// postActivationPayload POSTs a pre-built activation request body and
+// reports whether SAP's check actually executed, along with the joined text
+// of any error-severity checklist messages. It does not retry — callers
+// loop using activationRetryDelays.
+func (c *ADTClientImpl) postActivationPayload(ctx context.Context, payload string) (checkExecuted bool, errText string, err error) {
+	activateURL := c.baseURL + "/activation?method=activate&preauditRequested=true&sap-client=" + c.config.Client + "&sap-language=" + c.config.Language
+	req, err := http.NewRequestWithContext(ctx, "POST", activateURL, strings.NewReader(payload))
+	if err != nil {
+		return false, "", fmt.Errorf("failed to create activation request: %w", err)
+	}
+	c.addAuthHeaders(req)
+	req.Header.Set("Content-Type", "application/*")
+	req.Header.Set("Accept", "application/*")
+	req.Header.Set("X-CSRF-Token", c.csrfToken)
+	resp, err := c.doRequest(req)
+	if err != nil {
+		return false, "", fmt.Errorf("activation request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return false, "", fmt.Errorf("activation failed: HTTP %d - %s", resp.StatusCode, string(body))
+	}
+	checked, msgText := activationChecklistOutcome(body)
+	return checked, msgText, nil
+}
+
+// activatePayloadWithRetry drives postActivationPayload through
+// activationRetryDelays, returning an error unless SAP confirms the check
+// actually ran (checkExecuted) with no error-severity messages.
+func (c *ADTClientImpl) activatePayloadWithRetry(ctx context.Context, payload, name string) error {
+	for _, d := range activationRetryDelays {
+		if d > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(d):
+			}
+		}
+		checked, errText, err := c.postActivationPayload(ctx, payload)
+		if err != nil {
+			return err
+		}
+		if !checked {
+			continue
+		}
+		if errText != "" {
+			return fmt.Errorf("activation of %s failed: %s", name, errText)
+		}
+		return nil
+	}
+	return fmt.Errorf("activation of %s could not be confirmed after %d attempts (SAP never executed the check)", name, len(activationRetryDelays))
+}
+
+// activateWithRetry builds the default-namespace objectReferences activation
+// payload (used for source-text objects) and drives it through
+// activatePayloadWithRetry.
+func (c *ADTClientImpl) activateWithRetry(ctx context.Context, uri, name string) error {
+	activationReq := ActivationRequest{
+		Namespace: "http://www.sap.com/adt/core",
+		ObjectRef: ActivationRef{URI: uri, Name: strings.ToUpper(name)},
+	}
+	xmlPayload, err := xml.Marshal(activationReq)
+	if err != nil {
+		return fmt.Errorf("marshal activation: %w", err)
+	}
+	payload := `<?xml version="1.0" encoding="UTF-8"?>` + "\n" + string(xmlPayload)
+	return c.activatePayloadWithRetry(ctx, payload, name)
 }
 
 // ActivateObject activates an ABAP object (program, class, interface, etc.)
@@ -3003,9 +3424,9 @@ func (c *ADTClientImpl) ActivateObject(ctx context.Context, objectType, objectNa
 			for _, msg := range activationResp.Messages {
 				result.Messages = append(result.Messages, types.ActivationMessage{
 					Severity: msg.Severity,
-					Text:     strings.TrimSpace(msg.Text),
+					Text:     msg.Text(),
 				})
-				if msg.Severity == "error" || msg.Severity == "E" {
+				if isActivationError(msg.Severity) {
 					result.Success = false
 				}
 			}

--- a/internal/adt/create_payload_test.go
+++ b/internal/adt/create_payload_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/xml"
 	"strings"
 	"testing"
+
+	"github.com/bluefunda/abaper/types"
 )
 
 // These tests marshal the create-shell XML payloads used by the various
@@ -94,5 +96,137 @@ func TestDDLSourceCreatePayload(t *testing.T) {
 	}
 	if !strings.Contains(xmlStr, `adtcore:type="DDLS/DF"`) {
 		t.Errorf("expected adtcore:type=\"DDLS/DF\", got: %s", xmlStr)
+	}
+}
+
+// TestSRVDSourceCreatePayload guards the srvd:srvdSourceType="S" attribute,
+// which SAP requires and silently rejects with "Service Definition type ''
+// does not exist" if missing — found only via live testing against
+// abap.bluefunda.com (see docs/OBJECT_TYPE_PARITY_PLAN.md item 6 follow-up).
+func TestSRVDSourceCreatePayload(t *testing.T) {
+	payload := srvdSourceCreatePayload{
+		SrvdNS:         "http://www.sap.com/adt/ddic/srvdsources",
+		AdtcoreNS:      "http://www.sap.com/adt/core",
+		Description:    "test service definition",
+		Name:           "ZTEST_SD",
+		Type:           "SRVD/SRV",
+		Language:       "EN",
+		MasterLanguage: "EN",
+		Responsible:    "DEVELOPER",
+		SourceType:     "S",
+		PackageRef:     classPackageRef{Name: "$TMP"},
+	}
+	out, err := xml.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	xmlStr := string(out)
+
+	if !strings.Contains(xmlStr, `<srvd:srvdSource`) {
+		t.Errorf("expected root element srvd:srvdSource, got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `adtcore:type="SRVD/SRV"`) {
+		t.Errorf("expected adtcore:type=\"SRVD/SRV\", got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `srvd:srvdSourceType="S"`) {
+		t.Errorf(`expected srvd:srvdSourceType="S" (SAP rejects creation without it), got: %s`, xmlStr)
+	}
+}
+
+// TestServiceBindingCreatePayload guards the srvb:serviceBinding shape SAP
+// accepts for a full create-in-one-POST (no separate lock/PUT needed, unlike
+// domains/data elements) — confirmed live against abap.bluefunda.com.
+func TestServiceBindingCreatePayload(t *testing.T) {
+	payload := serviceBindingPayload{
+		SrvbNS:         "http://www.sap.com/adt/ddic/ServiceBindings",
+		AdtcoreNS:      "http://www.sap.com/adt/core",
+		Description:    "test service binding",
+		Name:           "ZTEST_SB",
+		Type:           "SRVB/SVB",
+		Language:       "EN",
+		MasterLanguage: "EN",
+		Responsible:    "DEVELOPER",
+		PackageRef:     classPackageRef{Name: "$TMP"},
+		Services: srvbServices{
+			Name: "ZTEST_SB",
+			Content: srvbContent{
+				Version:           "0001",
+				ServiceDefinition: srvbServiceRef{Name: "ZTEST_SD"},
+			},
+		},
+		Binding: srvbBinding{
+			Category:       "0",
+			Type:           "ODATA",
+			Version:        "V4",
+			Implementation: srvbImplementation{Name: ""},
+		},
+	}
+	out, err := xml.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	xmlStr := string(out)
+
+	if !strings.Contains(xmlStr, `<srvb:serviceBinding`) {
+		t.Errorf("expected root element srvb:serviceBinding, got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `adtcore:type="SRVB/SVB"`) {
+		t.Errorf("expected adtcore:type=\"SRVB/SVB\", got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `srvb:type="ODATA"`) || !strings.Contains(xmlStr, `srvb:version="V4"`) {
+		t.Errorf("expected ODATA V4 binding type, got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `<srvb:serviceDefinition adtcore:name="ZTEST_SD"`) {
+		t.Errorf("expected serviceDefinition reference to ZTEST_SD, got: %s", xmlStr)
+	}
+}
+
+// TestBuildServiceBindingPayloadDefaults guards the V4/UI defaults applied
+// when the caller doesn't specify a binding version/category — this feature
+// targets RAP V4 services, so V4+UI ("0") is the sensible default.
+func TestBuildServiceBindingPayloadDefaults(t *testing.T) {
+	c := &ADTClientImpl{config: &types.ADTConfig{Username: "developer"}}
+	out, err := c.buildServiceBindingPayload("ZTEST_SB", types.ServiceBindingProperties{
+		ServiceDefinitionName: "ZTEST_SD",
+	})
+	if err != nil {
+		t.Fatalf("buildServiceBindingPayload: %v", err)
+	}
+	xmlStr := string(out)
+	if !strings.Contains(xmlStr, `srvb:version="V4"`) {
+		t.Errorf("expected default binding version V4, got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `srvb:category="0"`) {
+		t.Errorf("expected default binding category \"0\" (UI), got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `adtcore:responsible="DEVELOPER"`) {
+		t.Errorf("expected responsible to be uppercased from config username, got: %s", xmlStr)
+	}
+}
+
+// TestServiceBindingReadResponseParsing guards parsing of the live SAP
+// srvb:serviceBinding GET response shape (namespace-prefixed elements and
+// attributes, matched here by local name only).
+func TestServiceBindingReadResponseParsing(t *testing.T) {
+	sample := `<?xml version="1.0" encoding="utf-8"?><srvb:serviceBinding srvb:contract="C2" srvb:releaseSupported="true" srvb:published="true" srvb:bindingCreated="true" adtcore:responsible="DEVELOPER" adtcore:name="ZTEST_SB" adtcore:type="SRVB/SVB" adtcore:version="active" adtcore:description="test binding" xmlns:srvb="http://www.sap.com/adt/ddic/ServiceBindings" xmlns:adtcore="http://www.sap.com/adt/core"><srvb:services srvb:name="ZTEST_SB"><srvb:content srvb:version="0001"><srvb:serviceDefinition adtcore:uri="/sap/bc/adt/ddic/srvd/sources/ztest_sd" adtcore:type="SRVD/SRV" adtcore:name="ZTEST_SD"/></srvb:content></srvb:services><srvb:binding srvb:type="ODATA" srvb:version="V4" srvb:category="0"><srvb:implementation adtcore:name="ZTEST_SB"/></srvb:binding></srvb:serviceBinding>`
+
+	var parsed serviceBindingReadResponse
+	if err := xml.Unmarshal([]byte(sample), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Description != "test binding" {
+		t.Errorf("expected description %q, got %q", "test binding", parsed.Description)
+	}
+	if !parsed.Published {
+		t.Errorf("expected published=true")
+	}
+	if parsed.Version != "active" {
+		t.Errorf("expected version=active, got %q", parsed.Version)
+	}
+	if parsed.Services.Content.ServiceDefinition.Name != "ZTEST_SD" {
+		t.Errorf("expected service definition name ZTEST_SD, got %q", parsed.Services.Content.ServiceDefinition.Name)
+	}
+	if parsed.Binding.Version != "V4" || parsed.Binding.Category != "0" {
+		t.Errorf("expected binding V4/category 0, got version=%q category=%q", parsed.Binding.Version, parsed.Binding.Category)
 	}
 }

--- a/rest/models/api.go
+++ b/rest/models/api.go
@@ -23,6 +23,9 @@ type APIRequest struct {
 	// Structured properties for DDIC objects that are not source-text based.
 	DomainProperties      *types.DomainProperties      `json:"domain_properties,omitempty"`
 	DataElementProperties *types.DataElementProperties `json:"data_element_properties,omitempty"`
+
+	// Structured properties for a Service Binding (SRVB/SVB, not source-text).
+	ServiceBindingProperties *types.ServiceBindingProperties `json:"service_binding_properties,omitempty"`
 }
 
 // APIResponse is the standard response envelope. T is the data payload type.

--- a/rest/server/fake_adt_client_test.go
+++ b/rest/server/fake_adt_client_test.go
@@ -13,34 +13,41 @@ type fakeADTClient struct {
 	authenticated bool
 	testConnErr   error
 
-	getProgramFn         func(ctx context.Context, name string) (*types.ADTSourceCode, error)
-	getPackageContentsFn func(ctx context.Context, name string) (*types.ADTPackage, error)
-	getNodeContentsFn    func(ctx context.Context, name string) (*types.PackageContentsResult, error)
-	listPackagesFn       func(ctx context.Context, pattern string) ([]types.ADTPackage, error)
-	searchObjectsFn      func(ctx context.Context, pattern string, objectTypes []string) (*types.ADTSearchResult, error)
-	updateProgramFn      func(ctx context.Context, name, source string) error
-	updateClassFn        func(ctx context.Context, name, source string) error
-	updateFunctionFn     func(ctx context.Context, functionName, functionGroup, source string) error
-	updateTableFn        func(ctx context.Context, name, source string) error
-	updateStructureFn    func(ctx context.Context, name, source string) error
-	updateDDLSFn         func(ctx context.Context, name, source string) error
-	createProgramFn      func(ctx context.Context, name, description, packageName, source string) error
-	createClassFn        func(ctx context.Context, name, description, packageName, source string) error
-	createFunctionFn     func(ctx context.Context, name, functionGroup, description, source string) error
-	createDDLSFn         func(ctx context.Context, name, description, source string) error
-	createDomainFn       func(ctx context.Context, name string, props types.DomainProperties) error
-	updateDomainFn       func(ctx context.Context, name string, props types.DomainProperties) error
-	createDataElementFn  func(ctx context.Context, name string, props types.DataElementProperties) error
-	updateDataElementFn  func(ctx context.Context, name string, props types.DataElementProperties) error
-	getTypeInfoFn        func(ctx context.Context, typeName string) (*types.ADTTypeInfo, error)
-	activateObjectFn     func(ctx context.Context, objectType, objectName string) (*types.ActivationResult, error)
-	runUnitTestsFn       func(ctx context.Context, objectType, objectName string) (*types.UnitTestResult, error)
-	syntaxCheckFn        func(ctx context.Context, objectType, objectName, source string) (*types.SyntaxCheckResult, error)
-	formatSourceFn       func(ctx context.Context, source string) (string, error)
-	completionFn         func(ctx context.Context, objectType, objectName, source string, line, col int) ([]types.CompletionProposal, error)
-	navigationFn         func(ctx context.Context, objectType, objectName, source string, line, col int) (*types.NavigationTarget, error)
-	transportInfoFn      func(ctx context.Context, objectType, objectName string) (*types.ADTTransportInfo, error)
-	createTransportFn    func(ctx context.Context, objectType, objectName, description, packageName string) (string, error)
+	getProgramFn            func(ctx context.Context, name string) (*types.ADTSourceCode, error)
+	getSRVDSourceFn         func(ctx context.Context, name string) (*types.ADTSourceCode, error)
+	getPackageContentsFn    func(ctx context.Context, name string) (*types.ADTPackage, error)
+	getNodeContentsFn       func(ctx context.Context, name string) (*types.PackageContentsResult, error)
+	listPackagesFn          func(ctx context.Context, pattern string) ([]types.ADTPackage, error)
+	searchObjectsFn         func(ctx context.Context, pattern string, objectTypes []string) (*types.ADTSearchResult, error)
+	updateProgramFn         func(ctx context.Context, name, source string) error
+	updateClassFn           func(ctx context.Context, name, source string) error
+	updateFunctionFn        func(ctx context.Context, functionName, functionGroup, source string) error
+	updateTableFn           func(ctx context.Context, name, source string) error
+	updateStructureFn       func(ctx context.Context, name, source string) error
+	updateDDLSFn            func(ctx context.Context, name, source string) error
+	createProgramFn         func(ctx context.Context, name, description, packageName, source string) error
+	createClassFn           func(ctx context.Context, name, description, packageName, source string) error
+	createFunctionFn        func(ctx context.Context, name, functionGroup, description, source string) error
+	createDDLSFn            func(ctx context.Context, name, description, source string) error
+	createSRVDFn            func(ctx context.Context, name, description, source string) error
+	updateSRVDFn            func(ctx context.Context, name, source string) error
+	createDomainFn          func(ctx context.Context, name string, props types.DomainProperties) error
+	updateDomainFn          func(ctx context.Context, name string, props types.DomainProperties) error
+	createDataElementFn     func(ctx context.Context, name string, props types.DataElementProperties) error
+	updateDataElementFn     func(ctx context.Context, name string, props types.DataElementProperties) error
+	getServiceBindingFn     func(ctx context.Context, name string) (*types.ADTServiceBinding, error)
+	createServiceBindingFn  func(ctx context.Context, name string, props types.ServiceBindingProperties) error
+	updateServiceBindingFn  func(ctx context.Context, name string, props types.ServiceBindingProperties) error
+	publishServiceBindingFn func(ctx context.Context, name string) (*types.ServiceBindingPublishResult, error)
+	getTypeInfoFn           func(ctx context.Context, typeName string) (*types.ADTTypeInfo, error)
+	activateObjectFn        func(ctx context.Context, objectType, objectName string) (*types.ActivationResult, error)
+	runUnitTestsFn          func(ctx context.Context, objectType, objectName string) (*types.UnitTestResult, error)
+	syntaxCheckFn           func(ctx context.Context, objectType, objectName, source string) (*types.SyntaxCheckResult, error)
+	formatSourceFn          func(ctx context.Context, source string) (string, error)
+	completionFn            func(ctx context.Context, objectType, objectName, source string, line, col int) ([]types.CompletionProposal, error)
+	navigationFn            func(ctx context.Context, objectType, objectName, source string, line, col int) (*types.NavigationTarget, error)
+	transportInfoFn         func(ctx context.Context, objectType, objectName string) (*types.ADTTransportInfo, error)
+	createTransportFn       func(ctx context.Context, objectType, objectName, description, packageName string) (string, error)
 }
 
 func (f *fakeADTClient) Authenticate() error              { return nil }
@@ -77,6 +84,12 @@ func (f *fakeADTClient) GetFunctionGroup(ctx context.Context, name string) (*typ
 }
 func (f *fakeADTClient) GetDDLSource(ctx context.Context, name string) (*types.ADTSourceCode, error) {
 	return &types.ADTSourceCode{ObjectName: name, ObjectType: "DDLS"}, nil
+}
+func (f *fakeADTClient) GetSRVDSource(ctx context.Context, name string) (*types.ADTSourceCode, error) {
+	if f.getSRVDSourceFn != nil {
+		return f.getSRVDSourceFn(ctx, name)
+	}
+	return &types.ADTSourceCode{ObjectName: name, ObjectType: "SRVD"}, nil
 }
 func (f *fakeADTClient) GetObjectSource(ctx context.Context, objectType, objectName string) (string, error) {
 	return "", nil
@@ -124,6 +137,12 @@ func (f *fakeADTClient) CreateDDLS(ctx context.Context, name, description, sourc
 	}
 	return nil
 }
+func (f *fakeADTClient) CreateSRVD(ctx context.Context, name, description, source string) error {
+	if f.createSRVDFn != nil {
+		return f.createSRVDFn(ctx, name, description, source)
+	}
+	return nil
+}
 func (f *fakeADTClient) UpdateProgram(ctx context.Context, name, source string) error {
 	if f.updateProgramFn != nil {
 		return f.updateProgramFn(ctx, name, source)
@@ -167,6 +186,12 @@ func (f *fakeADTClient) UpdateDDLS(ctx context.Context, name, source string) err
 	}
 	return nil
 }
+func (f *fakeADTClient) UpdateSRVD(ctx context.Context, name, source string) error {
+	if f.updateSRVDFn != nil {
+		return f.updateSRVDFn(ctx, name, source)
+	}
+	return nil
+}
 func (f *fakeADTClient) CreateDomain(ctx context.Context, name string, props types.DomainProperties) error {
 	if f.createDomainFn != nil {
 		return f.createDomainFn(ctx, name, props)
@@ -190,6 +215,31 @@ func (f *fakeADTClient) UpdateDataElement(ctx context.Context, name string, prop
 		return f.updateDataElementFn(ctx, name, props)
 	}
 	return nil
+}
+
+func (f *fakeADTClient) GetServiceBinding(ctx context.Context, name string) (*types.ADTServiceBinding, error) {
+	if f.getServiceBindingFn != nil {
+		return f.getServiceBindingFn(ctx, name)
+	}
+	return &types.ADTServiceBinding{Name: name}, nil
+}
+func (f *fakeADTClient) CreateServiceBinding(ctx context.Context, name string, props types.ServiceBindingProperties) error {
+	if f.createServiceBindingFn != nil {
+		return f.createServiceBindingFn(ctx, name, props)
+	}
+	return nil
+}
+func (f *fakeADTClient) UpdateServiceBinding(ctx context.Context, name string, props types.ServiceBindingProperties) error {
+	if f.updateServiceBindingFn != nil {
+		return f.updateServiceBindingFn(ctx, name, props)
+	}
+	return nil
+}
+func (f *fakeADTClient) PublishServiceBinding(ctx context.Context, name string) (*types.ServiceBindingPublishResult, error) {
+	if f.publishServiceBindingFn != nil {
+		return f.publishServiceBindingFn(ctx, name)
+	}
+	return &types.ServiceBindingPublishResult{Severity: "OK"}, nil
 }
 
 func (f *fakeADTClient) SearchObjects(ctx context.Context, pattern string, objectTypes []string) (*types.ADTSearchResult, error) {

--- a/rest/server/server.go
+++ b/rest/server/server.go
@@ -109,6 +109,7 @@ func (rs *RestServer) Handler() http.Handler {
 	mux.HandleFunc("/api/v1/objects/list", rs.corsHandler(rs.listObjectsHandler))
 	mux.HandleFunc("/api/v1/objects/activate", rs.corsHandler(rs.activateObjectHandler))
 	mux.HandleFunc("/api/v1/activate", rs.corsHandler(rs.activateObjectHandler)) // alias used by all external clients
+	mux.HandleFunc("/api/v1/service-bindings/publish", rs.corsHandler(rs.publishServiceBindingHandler))
 	mux.HandleFunc("/api/v1/packages/contents", rs.corsHandler(rs.packageContentsHandler))
 	mux.HandleFunc("/api/v1/syntax-check", rs.corsHandler(rs.syntaxCheckHandler))
 	mux.HandleFunc("/api/v1/format", rs.corsHandler(rs.formatSourceHandler))
@@ -251,6 +252,10 @@ func (rs *RestServer) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 		result, err = c.GetTable(ctx, objectName)
 	case "DDLS", "DATA_DEFINITION":
 		result, err = c.GetDDLSource(ctx, objectName)
+	case "SRVD", "SERVICE_DEFINITION":
+		result, err = c.GetSRVDSource(ctx, objectName)
+	case "SRVB", "SERVICE_BINDING":
+		result, err = c.GetServiceBinding(ctx, objectName)
 	case "FUNCTIONGROUP", "FUGR":
 		result, err = c.GetFunctionGroup(ctx, objectName)
 	case "DOMAIN", "DOMA":
@@ -328,6 +333,8 @@ func (rs *RestServer) createObjectHandler(w http.ResponseWriter, r *http.Request
 			saveErr = c.UpdateStructure(ctx, objectName, req.Source)
 		case "DDLS", "DATA_DEFINITION":
 			saveErr = c.UpdateDDLS(ctx, objectName, req.Source)
+		case "SRVD", "SERVICE_DEFINITION":
+			saveErr = c.UpdateSRVD(ctx, objectName, req.Source)
 		default:
 			rs.sendError(w, "unsupported object type for save: "+objectType, http.StatusBadRequest)
 			return
@@ -388,6 +395,8 @@ func (rs *RestServer) createObjectHandler(w http.ResponseWriter, r *http.Request
 		err = c.CreateFunction(ctx, objectName, strings.ToUpper(req.Args[0]), description, sourceCode)
 	case "DDLS", "DATA_DEFINITION":
 		err = c.CreateDDLS(ctx, objectName, description, sourceCode)
+	case "SRVD", "SERVICE_DEFINITION":
+		err = c.CreateSRVD(ctx, objectName, description, sourceCode)
 	case "DOMAIN", "DOMA":
 		if req.DomainProperties == nil {
 			rs.sendError(w, "domain_properties is required to create a domain", http.StatusBadRequest)
@@ -408,6 +417,16 @@ func (rs *RestServer) createObjectHandler(w http.ResponseWriter, r *http.Request
 			props.Description = description
 		}
 		err = c.CreateDataElement(ctx, objectName, props)
+	case "SRVB", "SERVICE_BINDING":
+		if req.ServiceBindingProperties == nil {
+			rs.sendError(w, "service_binding_properties is required to create a service binding", http.StatusBadRequest)
+			return
+		}
+		props := *req.ServiceBindingProperties
+		if props.Description == "" {
+			props.Description = description
+		}
+		err = c.CreateServiceBinding(ctx, objectName, props)
 	default:
 		rs.sendError(w, "unsupported object type for creation: "+objectType, http.StatusBadRequest)
 		return
@@ -626,6 +645,17 @@ func (rs *RestServer) saveObjectHandler(w http.ResponseWriter, r *http.Request) 
 		}
 		rs.sendSuccess(w, map[string]any{"object_name": objectName, "object_type": objectType, "message": fmt.Sprintf("%s %s saved successfully", objectType, objectName)})
 		return
+	case "SRVB", "SERVICE_BINDING":
+		if req.ServiceBindingProperties == nil {
+			rs.sendError(w, "service_binding_properties is required to update a service binding", http.StatusBadRequest)
+			return
+		}
+		if err := c.UpdateServiceBinding(ctx, objectName, *req.ServiceBindingProperties); err != nil {
+			rs.sendError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rs.sendSuccess(w, map[string]any{"object_name": objectName, "object_type": objectType, "message": fmt.Sprintf("%s %s saved successfully", objectType, objectName)})
+		return
 	}
 
 	if req.Source == "" {
@@ -655,6 +685,8 @@ func (rs *RestServer) saveObjectHandler(w http.ResponseWriter, r *http.Request) 
 		err = c.UpdateStructure(ctx, objectName, req.Source)
 	case "DDLS", "DATA_DEFINITION":
 		err = c.UpdateDDLS(ctx, objectName, req.Source)
+	case "SRVD", "SERVICE_DEFINITION":
+		err = c.UpdateSRVD(ctx, objectName, req.Source)
 	default:
 		rs.sendError(w, "unsupported object type for save: "+objectType, http.StatusBadRequest)
 		return
@@ -723,6 +755,36 @@ func (rs *RestServer) activateObjectHandler(w http.ResponseWriter, r *http.Reque
 		"activated":   result.Success,
 		"messages":    result.Messages,
 	})
+}
+
+// publishServiceBindingHandler registers a Service Binding's OData service
+// at runtime. The binding must already be created and active.
+func (rs *RestServer) publishServiceBindingHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		rs.sendError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req models.APIRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		rs.sendError(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.ObjectName == "" {
+		rs.sendError(w, "object_name is required", http.StatusBadRequest)
+		return
+	}
+	c, err := rs.clientForRequest(r)
+	if err != nil {
+		rs.sendError(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	objectName := strings.ToUpper(req.ObjectName)
+	result, err := c.PublishServiceBinding(r.Context(), objectName)
+	if err != nil {
+		rs.sendError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	rs.sendSuccess(w, result)
 }
 
 func (rs *RestServer) syntaxCheckHandler(w http.ResponseWriter, r *http.Request) {

--- a/rest/server/server_test.go
+++ b/rest/server/server_test.go
@@ -155,6 +155,51 @@ func TestGetObjectHandler(t *testing.T) {
 		}
 	})
 
+	t.Run("srvd", func(t *testing.T) {
+		var gotName string
+		fake := &fakeADTClient{
+			getSRVDSourceFn: func(ctx context.Context, name string) (*types.ADTSourceCode, error) {
+				gotName = name
+				return &types.ADTSourceCode{ObjectName: name, ObjectType: "SRVD"}, nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/get", map[string]string{
+			"object_type": "srvd",
+			"object_name": "zabpb_sd1",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if gotName != "ZABPB_SD1" {
+			t.Errorf("expected uppercased object name passed through, got %q", gotName)
+		}
+		data := decodeSuccess[types.ADTSourceCode](t, rec)
+		if data.ObjectType != "SRVD" {
+			t.Errorf("expected ObjectType SRVD, got %q", data.ObjectType)
+		}
+	})
+
+	t.Run("srvb", func(t *testing.T) {
+		fake := &fakeADTClient{
+			getServiceBindingFn: func(ctx context.Context, name string) (*types.ADTServiceBinding, error) {
+				return &types.ADTServiceBinding{Name: name, ServiceDefinitionName: "ZABPB_SD1", BindingVersion: "V4", Published: true}, nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/get", map[string]string{
+			"object_type": "srvb",
+			"object_name": "zabpb_sb1",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		data := decodeSuccess[types.ADTServiceBinding](t, rec)
+		if data.ServiceDefinitionName != "ZABPB_SD1" || data.BindingVersion != "V4" || !data.Published {
+			t.Errorf("unexpected service binding data: %+v", data)
+		}
+	})
+
 	t.Run("missing fields", func(t *testing.T) {
 		rs := newTestServer(t, &fakeADTClient{})
 		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/get", map[string]string{"object_type": "program"})
@@ -302,6 +347,75 @@ func TestCreateObjectHandler(t *testing.T) {
 			t.Errorf("expected name=ZABPB_CDS1 with source, got name=%q source=%q", gotName, gotSource)
 		}
 	})
+
+	t.Run("srvd create", func(t *testing.T) {
+		var gotName, gotSource string
+		fake := &fakeADTClient{
+			createSRVDFn: func(ctx context.Context, name, description, source string) error {
+				gotName, gotSource = name, source
+				return nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/create", map[string]string{
+			"object_type": "srvd",
+			"object_name": "zabpb_sd1",
+			"description": "test service definition",
+			"source":      "define service ZABPB_SD1 { expose zabpb_cds1; }",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if gotName != "ZABPB_SD1" || gotSource == "" {
+			t.Errorf("expected name=ZABPB_SD1 with source, got name=%q source=%q", gotName, gotSource)
+		}
+	})
+
+	t.Run("srvb create requires service_binding_properties", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/create", map[string]any{
+			"object_type": "srvb",
+			"object_name": "zabpb_sb1",
+			"description": "test service binding",
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("srvb create", func(t *testing.T) {
+		var gotName string
+		var gotProps types.ServiceBindingProperties
+		fake := &fakeADTClient{
+			createServiceBindingFn: func(ctx context.Context, name string, props types.ServiceBindingProperties) error {
+				gotName, gotProps = name, props
+				return nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/create", map[string]any{
+			"object_type": "srvb",
+			"object_name": "zabpb_sb1",
+			"description": "test service binding",
+			"service_binding_properties": map[string]any{
+				"service_definition_name": "zabpb_sd1",
+				"binding_version":         "V4",
+				"binding_category":        "0",
+			},
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if gotName != "ZABPB_SB1" {
+			t.Errorf("expected uppercased name ZABPB_SB1, got %q", gotName)
+		}
+		if gotProps.ServiceDefinitionName != "zabpb_sd1" || gotProps.BindingVersion != "V4" {
+			t.Errorf("expected properties passed through, got %+v", gotProps)
+		}
+		if gotProps.Description != "test service binding" {
+			t.Errorf("expected description to default from request description, got %q", gotProps.Description)
+		}
+	})
 }
 
 // --- objects/save ---
@@ -403,6 +517,64 @@ func TestSaveObjectHandler(t *testing.T) {
 		}
 		if !called {
 			t.Error("expected UpdateDDLS to be called")
+		}
+	})
+
+	t.Run("updates srvd", func(t *testing.T) {
+		var called bool
+		fake := &fakeADTClient{
+			updateSRVDFn: func(ctx context.Context, name, source string) error {
+				called = true
+				return nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/save", map[string]string{
+			"object_type": "srvd",
+			"object_name": "zabpb_sd1",
+			"source":      "define service ZABPB_SD1 { expose zabpb_cds1; }",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if !called {
+			t.Error("expected UpdateSRVD to be called")
+		}
+	})
+
+	t.Run("updates srvb via service_binding_properties", func(t *testing.T) {
+		var called bool
+		fake := &fakeADTClient{
+			updateServiceBindingFn: func(ctx context.Context, name string, props types.ServiceBindingProperties) error {
+				called = true
+				return nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/save", map[string]any{
+			"object_type": "srvb",
+			"object_name": "zabpb_sb1",
+			"service_binding_properties": map[string]any{
+				"service_definition_name": "zabpb_sd1",
+				"binding_version":         "V4",
+			},
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if !called {
+			t.Error("expected UpdateServiceBinding to be called")
+		}
+	})
+
+	t.Run("srvb save requires service_binding_properties", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/objects/save", map[string]string{
+			"object_type": "srvb",
+			"object_name": "zabpb_sb1",
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
 		}
 	})
 
@@ -605,6 +777,50 @@ func TestActivateObjectHandler(t *testing.T) {
 		}
 		if !saved {
 			t.Errorf("expected UpdateProgram to be called before activation")
+		}
+	})
+}
+
+// --- service-bindings/publish ---
+
+func TestPublishServiceBindingHandler(t *testing.T) {
+	t.Run("publishes", func(t *testing.T) {
+		var gotName string
+		fake := &fakeADTClient{
+			publishServiceBindingFn: func(ctx context.Context, name string) (*types.ServiceBindingPublishResult, error) {
+				gotName = name
+				return &types.ServiceBindingPublishResult{Severity: "OK", ShortText: name + " published locally"}, nil
+			},
+		}
+		rs := newTestServer(t, fake)
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/service-bindings/publish", map[string]string{
+			"object_name": "zabpb_sb1",
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if gotName != "ZABPB_SB1" {
+			t.Errorf("expected uppercased object name passed through, got %q", gotName)
+		}
+		data := decodeSuccess[types.ServiceBindingPublishResult](t, rec)
+		if data.Severity != "OK" {
+			t.Errorf("expected severity OK, got %q", data.Severity)
+		}
+	})
+
+	t.Run("missing object_name", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodPost, "/api/v1/service-bindings/publish", map[string]string{})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		rs := newTestServer(t, &fakeADTClient{})
+		rec := doJSON(t, rs, http.MethodGet, "/api/v1/service-bindings/publish", nil)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("expected 405, got %d", rec.Code)
 		}
 	})
 }

--- a/types/adt.go
+++ b/types/adt.go
@@ -75,15 +75,15 @@ type ADTTransportInfo struct {
 
 // ADT Configuration
 type ADTConfig struct {
-	Host            string `json:"host"`
-	Client          string `json:"client"`
-	Username        string `json:"username"`
-	Password        string `json:"password"`
-	Language        string `json:"language"`
-	AllowSelfSigned bool   `json:"allow_self_signed"`
+	Host            string        `json:"host"`
+	Client          string        `json:"client"`
+	Username        string        `json:"username"`
+	Password        string        `json:"password"`
+	Language        string        `json:"language"`
+	AllowSelfSigned bool          `json:"allow_self_signed"`
 	ConnectTimeout  time.Duration `json:"connect_timeout"`
 	RequestTimeout  time.Duration `json:"request_timeout"`
-	Debug           bool   `json:"debug"`
+	Debug           bool          `json:"debug"`
 }
 
 // Additional data structures for extended services
@@ -111,10 +111,10 @@ type ADTTableColumn struct {
 }
 
 type ADTTypeInfo struct {
-	TypeName    string                 `json:"type_name"`
-	TypeKind    string                 `json:"type_kind"` // "DOMAIN", "DATA_ELEMENT", etc.
-	Description string                 `json:"description"`
-	Source      string                 `json:"source"`
+	TypeName    string         `json:"type_name"`
+	TypeKind    string         `json:"type_kind"` // "DOMAIN", "DATA_ELEMENT", etc.
+	Description string         `json:"description"`
+	Source      string         `json:"source"`
 	Properties  map[string]any `json:"properties"`
 }
 
@@ -175,6 +175,7 @@ type SourceReader interface {
 	GetFunction(ctx context.Context, functionName, functionGroup string) (*ADTSourceCode, error)
 	GetFunctionGroup(ctx context.Context, name string) (*ADTSourceCode, error)
 	GetDDLSource(ctx context.Context, name string) (*ADTSourceCode, error)
+	GetSRVDSource(ctx context.Context, name string) (*ADTSourceCode, error)
 	GetObjectSource(ctx context.Context, objectType, objectName string) (string, error)
 	CheckObjectExists(ctx context.Context, objectType, objectName string) (bool, error)
 }
@@ -190,6 +191,7 @@ type SourceWriter interface {
 	CreateFunctionGroup(ctx context.Context, name, description, source string) error
 	CreateFunction(ctx context.Context, name, functionGroup, description, source string) error
 	CreateDDLS(ctx context.Context, name, description, source string) error
+	CreateSRVD(ctx context.Context, name, description, source string) error
 	UpdateProgram(ctx context.Context, name, source string) error
 	UpdateClass(ctx context.Context, name, source string) error
 	UpdateInclude(ctx context.Context, name, source string) error
@@ -199,6 +201,7 @@ type SourceWriter interface {
 	UpdateTable(ctx context.Context, name, source string) error
 	UpdateStructure(ctx context.Context, name, source string) error
 	UpdateDDLS(ctx context.Context, name, source string) error
+	UpdateSRVD(ctx context.Context, name, source string) error
 }
 
 // PackageNode is a single entry returned by the nodestructure endpoint.
@@ -261,6 +264,47 @@ type DDICPropertyWriter interface {
 	UpdateDataElement(ctx context.Context, name string, props DataElementProperties) error
 }
 
+// ServiceBindingProperties describes a Service Binding (SRVB/SVB): the
+// runtime OData exposure of a Service Definition. Like domains/data
+// elements, this is structured metadata, not ABAP source text.
+type ServiceBindingProperties struct {
+	Description           string `json:"description,omitempty"`
+	ServiceDefinitionName string `json:"service_definition_name"`    // the SRVD/SRV this binding exposes
+	BindingVersion        string `json:"binding_version,omitempty"`  // "V2" or "V4" (OData version); defaults to "V4"
+	BindingCategory       string `json:"binding_category,omitempty"` // "0"=UI, "1"=Web API; defaults to "0"
+}
+
+// ADTServiceBinding is the parsed result of reading a Service Binding.
+type ADTServiceBinding struct {
+	Name                  string `json:"name"`
+	Description           string `json:"description"`
+	ServiceDefinitionName string `json:"service_definition_name"`
+	BindingVersion        string `json:"binding_version"`
+	BindingCategory       string `json:"binding_category"`
+	Version               string `json:"version"` // active/inactive
+	Published             bool   `json:"published"`
+}
+
+// ServiceBindingPublishResult reports the outcome of publishing a Service
+// Binding, registering its OData service for runtime consumption.
+type ServiceBindingPublishResult struct {
+	Severity  string `json:"severity"`
+	ShortText string `json:"short_text"`
+	LongText  string `json:"long_text,omitempty"`
+}
+
+// RAPServiceWriter creates, updates and publishes RAP-exposed OData
+// services (Service Bindings) that expose CDS views via a Service
+// Definition. Follows the same create -> lock -> set-properties -> unlock
+// -> activate flow as DDICPropertyWriter, plus a separate publish step to
+// register the runtime OData endpoint.
+type RAPServiceWriter interface {
+	GetServiceBinding(ctx context.Context, name string) (*ADTServiceBinding, error)
+	CreateServiceBinding(ctx context.Context, name string, props ServiceBindingProperties) error
+	UpdateServiceBinding(ctx context.Context, name string, props ServiceBindingProperties) error
+	PublishServiceBinding(ctx context.Context, name string) (*ServiceBindingPublishResult, error)
+}
+
 // PackageBrowser searches and navigates package contents.
 type PackageBrowser interface {
 	SearchObjects(ctx context.Context, pattern string, objectTypes []string) (*ADTSearchResult, error)
@@ -299,6 +343,7 @@ type ADTClient interface {
 	SourceReader
 	SourceWriter
 	DDICPropertyWriter
+	RAPServiceWriter
 	PackageBrowser
 	ObjectActivator
 	LangFeatures


### PR DESCRIPTION
## Summary
Closes #104

- Adds `GetSRVDSource`/`CreateSRVD`/`UpdateSRVD` (Service Definition, SRVD/SRV — source-text, mirrors the existing DDLS convention) and `GetServiceBinding`/`CreateServiceBinding`/`UpdateServiceBinding`/`PublishServiceBinding` (Service Binding, SRVB/SVB — structured XML) to the SDK, wired into the REST layer's get/create/update handlers plus a new `POST /api/v1/service-bindings/publish` endpoint that registers the runtime OData V4 service.
- Along the way, live testing against `abap.bluefunda.com` surfaced a latent activation bug affecting every object type that goes through `createAndPopulate` (interfaces, function groups, DDLS, and now SRVD): the code activated objects while still holding the edit lock, and every activation call site built the XML in the wrong (default/unprefixed) namespace — SAP silently no-ops the activation check for that form (`checkExecuted="false"`, zero messages) instead of erroring, so the API reported `"activated": true"` on objects that were actually left inactive. Fixed by unlocking before activating and switching to the `adtcore:`-prefixed activation payload every other ADT client uses (confirmed against the `abap-adt-api` reference implementation), plus parsing the activation checklist response instead of trusting HTTP 200 alone.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] Unit tests: `rest/server/server_test.go` + `fake_adt_client_test.go` cover SRVD/SRVB get/create/update + publish handlers; `internal/adt/create_payload_test.go` + new `internal/adt/activation_checklist_test.go` cover the create-payload shapes and the activation-checklist parsing (including the exact `checkExecuted="false"` regression fixture)
- [x] Live verification against `abap.bluefunda.com`: created a CDS view → SRVD exposing it → SRVB bound as ODATA V4 UI → activated → published → confirmed the resulting `/sap/opu/odata4/...` service is registered live, all on the first attempt with no manual workaround